### PR TITLE
Add manual emulator override to PsychToolboxAudio

### DIFF
--- a/Functions/Plugins/PsychToolboxAudio/PsychToolboxAudio.m
+++ b/Functions/Plugins/PsychToolboxAudio/PsychToolboxAudio.m
@@ -35,12 +35,15 @@ classdef PsychToolboxAudio < handle
     end
     
     methods
-        function obj = PsychToolboxAudio
+        function obj = PsychToolboxAudio(emulator_flag)
             global BpodSystem
             if isprop(BpodSystem, 'EmulatorMode')
                 obj.EmulatorMode = BpodSystem.EmulatorMode;
             else
                 obj.EmulatorMode = 0;
+            end
+            if nargin == 1
+                obj.EmulatorMode = emulator_flag;
             end
             if obj.EmulatorMode == 0
                 try


### PR DESCRIPTION
Sometimes I'm developing a task with with my personal computer and a state machine but I don't have the sound card, so a manual override is useful.