### PR TITLE
RubBpodEmulator: Fix emulator conditions wrongly handling global timers

### DIFF
--- a/Functions/Internal Functions/RunBpodEmulator.m
+++ b/Functions/Internal Functions/RunBpodEmulator.m
@@ -135,7 +135,11 @@ switch Op
                     TargetState = BpodSystem.StateMatrix.ConditionMatrix(BpodSystem.Emulator.CurrentState, x);
                     if TargetState ~= BpodSystem.Emulator.CurrentState
                         ThisChannel = BpodSystem.StateMatrix.ConditionChannels(x);
-                        HWState = BpodSystem.HardwareState.InputState(ThisChannel);                        
+                        if ThisChannel <= BpodSystem.HW.n.Inputs
+                            HWState = BpodSystem.HardwareState.InputState(ThisChannel);
+                        else
+                            HWState = BpodSystem.Emulator.GlobalTimersActive(ThisChannel-BpodSystem.HW.n.Inputs);
+                        end
                         if HWState == BpodSystem.StateMatrix.ConditionValues(x)
                             BpodSystem.Emulator.nCurrentEvents = BpodSystem.Emulator.nCurrentEvents + 1;
                             VirtualCurrentEvents(BpodSystem.Emulator.nCurrentEvents) = ConditionOffset+x;


### PR DESCRIPTION
The [documentation](https://sites.google.com/site/bpoddocumentation/bpod-user-guide/function-reference-beta/setcondition) mentions that one can use `SetCondition()` on Global Counters:
```
* ConditionChannel: The name of the input channel attached to the condition.
     Input channel names are listed in BpodSystem.StateMachineInfo.InputChannelNames
     The channel can also be a global timer, indicated as 'GlobalTimerN' where N is the index of the global tim
```

Although [SetCondition()](https://github.com/sanworks/Bpod_Gen2/blob/597dff65c8a5a31933b37db07674e8fe6ceed1d0/Functions/State%20Machine%20Assembler/SetCondition.m#L36-L41) correctly takes care of GlobalTimer, however [RunBpodEmulator()](https://github.com/sanworks/Bpod_Gen2/blob/597dff65c8a5a31933b37db07674e8fe6ceed1d0/Functions/Internal%20Functions/RunBpodEmulator.m#L138) doesn't do the same. This PR fixes this.

This is a test case that fails without this fix:
```MATLAB
function TestCondition
global BpodSystem
GlobalTimerID = 1;
if ~BpodSystem.EmulatorMode
    EncTimerID = GlobalTimerID;
else
    EncTimerID = dec2bin(GlobalTimerID, 3);
end
sma = NewStateMatrix();
sma = SetGlobalTimer(sma,GlobalTimerID,0.01);
sma = SetCondition(sma,1,'GlobalTimer1',0);
sma = AddState(sma, 'Name', 'Start', ...
    'Timer', 1,...
    'StateChangeConditions', {'Tup','Final'},...
    'OutputActions', {'GlobalTimerTrig',EncTimerID});
sma = AddState(sma, 'Name', 'Final', ...
    'Timer', 0,...
    'StateChangeConditions', {'Condition1','exit'},...
    'OutputActions', {});
SendStateMatrix(sma);
RunStateMatrix;
```

I've tested with a live bpod (r0.5) and it worked correctly, it's not affected by this bug.

