### PR TITLE
Fix CloseRequestFcn Error preventing main GUI from closing

### DIFF
--- a/Functions/EndBpod.m
+++ b/Functions/EndBpod.m
@@ -43,7 +43,11 @@ if ~isempty(BpodSystem)
     end
     if BpodSystem.Status.BeingUsed == 0
         if BpodSystem.EmulatorMode == 0
-            BpodSystem.SerialPort.write('Z', 'uint8');
+            try
+                BpodSystem.SerialPort.write('Z', 'uint8');
+            catch Error
+                disp("It appears that the BPOD may have been disconnected prematurely. Close GUI.")
+            end
         end
         pause(.1);
         delete(BpodSystem.GUIHandles.MainFig);

--- a/Functions/Launch manager/NewLaunchManager.m
+++ b/Functions/Launch manager/NewLaunchManager.m
@@ -233,7 +233,7 @@ else
     startPos = 2;
 end
 Candidates = dir(BpodSystem.Path.ProtocolFolder);
-ProtocolNames = cell(1);
+ProtocolNames = cell(0);
 nProtocols = 0;
 for x = startPos:length(Candidates)
     if Candidates(x).isdir
@@ -255,6 +255,7 @@ for x = startPos:length(Candidates)
         ProtocolNames{nProtocols} = ProtocolName;
     end
 end
+
 if isempty(ProtocolNames)
     ProtocolNames = {'No Protocols Found'};
 else


### PR DESCRIPTION
Add try:catch to close the GUI even when the BPOD no longer has a serial connection. This can occur if the user unplugs the BPOD without closing the GUI. If the user tries to close the GUI after the BPOD is disconnected, MATLAB throws an error and must be force closed.