### PR TITLE
Fix two GUI errors

### DIFF
--- a/Functions/EndBpod.m
+++ b/Functions/EndBpod.m
@@ -43,7 +43,11 @@ if ~isempty(BpodSystem)
     end
     if BpodSystem.Status.BeingUsed == 0
         if BpodSystem.EmulatorMode == 0
-            BpodSystem.SerialPort.write('Z', 'uint8');
+            try
+                BpodSystem.SerialPort.write('Z', 'uint8');
+            catch Error
+                disp("It appears that the BPOD may have been disconnected prematurely. Close GUI.")
+            end
         end
         pause(.1);
         delete(BpodSystem.GUIHandles.MainFig);

--- a/Functions/Launch manager/NewLaunchManager.m
+++ b/Functions/Launch manager/NewLaunchManager.m
@@ -233,7 +233,7 @@ else
     startPos = 2;
 end
 Candidates = dir(BpodSystem.Path.ProtocolFolder);
-ProtocolNames = cell(1);
+ProtocolNames = cell(0);
 nProtocols = 0;
 for x = startPos:length(Candidates)
     if Candidates(x).isdir
@@ -255,6 +255,7 @@ for x = startPos:length(Candidates)
         ProtocolNames{nProtocols} = ProtocolName;
     end
 end
+
 if isempty(ProtocolNames)
     ProtocolNames = {'No Protocols Found'};
 else


### PR DESCRIPTION
1) When trying to close the Bpod Console, if the Bpod was disconnected from USB early, the GUI will error out and wont close when trying to send the 'Z' command to the BPod. Added a small try:catch to allow the GUI to close even if the Serial command fails. Otherwise, the GUI hangs and must be force closed.

2) When trying to load the protocols, the GUI will error out if the folder is empty. This is due to the protocol list being instantiated to length = 1 instead of length = 0. So even if no protocols are present, it will try to continue on as if there are. 