### PR TITLE
Add manual emulator override to PsychToolboxAudio

### DIFF
--- a/Functions/Plugins/PsychToolboxAudio/PsychToolboxAudio.m
+++ b/Functions/Plugins/PsychToolboxAudio/PsychToolboxAudio.m
@@ -35,13 +35,18 @@ classdef PsychToolboxAudio < handle
     end
     
     methods
-        function obj = PsychToolboxAudio
+        function obj = PsychToolboxAudio(EmulatorModeOverride)
             global BpodSystem
             if isprop(BpodSystem, 'EmulatorMode')
                 obj.EmulatorMode = BpodSystem.EmulatorMode;
             else
                 obj.EmulatorMode = 0;
             end
+
+            if nargin == 1
+                obj.EmulatorMode = EmulatorModeOverride;
+            end
+
             if obj.EmulatorMode == 0
                 try
                     PsychPortAudio('Verbosity', 0);


### PR DESCRIPTION
When developing a task sometimes I'm using my laptop and a state machine, but the laptop doesn't have a sound card.
`BpodSystem.EmulatorMode` will be 0 but `PsychToolboxAudio` won't be able to access a Xonar card.
An override for the emulator mode can handle this situation with minimal changes to the protocol code.