### PR TITLE
An error will be thrown if the Protocol folder only contains folders.

### DIFF
--- a/Functions/Launch manager/LaunchManager.m
+++ b/Functions/Launch manager/LaunchManager.m
@@ -161,12 +161,21 @@ else
             selectedProtocol = iName+1;
         end
     end
+
+    if selectedProtocol > length(protocolNames)
+        % If somehow our counter is higher than the number of protocols
+        % The last thing in the list must have been a folder
+        % Reset to first item in list
+        selectedProtocol = 1;
+        set(BpodSystem.GUIHandles.ProtocolSelector, 'Value', selectedProtocol);
+        return;
+    end
+
     set(BpodSystem.GUIHandles.ProtocolSelector, 'Value', selectedProtocol);
     selectedProtocolName = protocolNames{selectedProtocol};
     BpodSystem.Status.CurrentProtocolName = selectedProtocolName;
     dataPath = fullfile(BpodSystem.Path.DataFolder,BpodSystem.GUIData.DummySubjectString);
     protocolName = BpodSystem.Status.CurrentProtocolName;
-
     %Make standard folders for this protocol.  This will fail silently if the folders exist
     warning off % Suppress warning that directory already exists
     mkdir(dataPath, protocolName);


### PR DESCRIPTION
The original code assumes there would be a .m file present at least one after the last folder, leading to an indexing error. This certainly feels like a Bandaid but, it works for now.

I am in the midst of trying to write something robust, so you can merge this patch for now if you'd like a temp fix. Or you can give me a little while and we'll see what I come up with!