### PR TITLE
Update oscilloscope poll/update rate when start/stop is called

### DIFF
--- a/Functions/Modules/Analog Input/BpodAnalogIn.m
+++ b/Functions/Modules/Analog Input/BpodAnalogIn.m
@@ -892,11 +892,19 @@ classdef BpodAnalogIn < handle
             drawnow;
         end
         
-        function scope_StartStop(obj)
+        function scope_StartStop(obj, pollrate)
             % scope_StartStop() toggles data acquisition by the scope()
             % GUI. It is called by a start button on the GUI, but it can also be 
             % called from a user protocol file to start analog data logging with
             % online monitoring.
+
+            % Make sure the user supplies a positive, floating-point number
+            if ~isfloat(pollrate)
+                error('Oscilloscope poll rate must be a number!');
+            elseif ~(pollrate > 0)
+                error('Oscilloscope poll rate must be greater than zero!');
+            end
+
             scopeReady = 1;
             if ~isfield(obj.UIhandles, 'OscopeFig')
                 scopeReady = 0;
@@ -927,7 +935,7 @@ classdef BpodAnalogIn < handle
                     end
                     obj.UIdata.SweepPos = 1;
                     obj.startUSBStream;
-                    obj.Timer = timer('TimerFcn',@(h,e)obj.updatePlot(), 'ExecutionMode', 'fixedRate', 'Period', 0.05);
+                    obj.Timer = timer('TimerFcn',@(h,e)obj.updatePlot(), 'ExecutionMode', 'fixedRate', 'Period', pollrate);
                     start(obj.Timer);
                 else
                     stop(obj.Timer);

--- a/Functions/Modules/Analog Input/BpodAnalogIn.m
+++ b/Functions/Modules/Analog Input/BpodAnalogIn.m
@@ -897,27 +897,20 @@ classdef BpodAnalogIn < handle
             % GUI. It is called by a start button on the GUI, but it can also be 
             % called from a user protocol file to start analog data logging with
             % online monitoring.
-
+            
+            % Default GUI update time is 0.05s
             default_update_time = 0.05;
             oscope_time = 0;
 
             ip = inputParser;
-            valid_update_time = @(time) isfloat(time) && isscalar(time) && (time > 0);
-            valid_obj = @(x) isa(x, 'BpodAnalogIn');
-            
-            addRequired(ip, 'obj', valid_obj);
-            addOptional(ip, 'oscope_time', default_update_time, valid_update_time);
+            valid_update_time = @(time) isfloat(time) && isscalar(time) && (time > 0);  % Update time must be a float, scalar, and greater than zero
+            valid_obj = @(x) isa(x, 'BpodAnalogIn'); % Have to also check obj is an instance of BpodAnalogIn
 
-            parse(ip, obj, varargin{:});
-            oscope_time = ip.Results.oscope_time;
-            
+            addRequired(ip, 'obj', valid_obj);  % instance is a required argument
+            addOptional(ip, 'oscope_time', default_update_time, valid_update_time); % oscope_time is optional, if the passed value is invalid, the default is used
 
-            % Make sure the user supplies a positive, floating-point number
-            if ~isfloat(pollrate)
-                error('Oscilloscope poll rate must be a number!');
-            elseif ~(pollrate > 0)
-                error('Oscilloscope poll rate must be greater than zero!');
-            end
+            parse(ip, obj, varargin{:});  % parse the args
+            oscope_time = ip.Results.oscope_time; % assuming all is well, grab the value from the parser
 
             scopeReady = 1;
             if ~isfield(obj.UIhandles, 'OscopeFig')

--- a/Functions/Modules/Analog Input/BpodAnalogIn.m
+++ b/Functions/Modules/Analog Input/BpodAnalogIn.m
@@ -892,11 +892,25 @@ classdef BpodAnalogIn < handle
             drawnow;
         end
         
-        function scope_StartStop(obj, pollrate)
+        function scope_StartStop(obj, varargin)
             % scope_StartStop() toggles data acquisition by the scope()
             % GUI. It is called by a start button on the GUI, but it can also be 
             % called from a user protocol file to start analog data logging with
             % online monitoring.
+
+            default_update_time = 0.05;
+            oscope_time = 0;
+
+            ip = inputParser;
+            valid_update_time = @(time) isfloat(time) && isscalar(time) && (time > 0);
+            valid_obj = @(x) isa(x, 'BpodAnalogIn');
+            
+            addRequired(ip, 'obj', valid_obj);
+            addOptional(ip, 'oscope_time', default_update_time, valid_update_time);
+
+            parse(ip, obj, varargin{:});
+            oscope_time = ip.Results.oscope_time;
+            
 
             % Make sure the user supplies a positive, floating-point number
             if ~isfloat(pollrate)
@@ -935,7 +949,7 @@ classdef BpodAnalogIn < handle
                     end
                     obj.UIdata.SweepPos = 1;
                     obj.startUSBStream;
-                    obj.Timer = timer('TimerFcn',@(h,e)obj.updatePlot(), 'ExecutionMode', 'fixedRate', 'Period', pollrate);
+                    obj.Timer = timer('TimerFcn',@(h,e)obj.updatePlot(), 'ExecutionMode', 'fixedRate', 'Period', oscope_time);
                     start(obj.Timer);
                 else
                     stop(obj.Timer);

--- a/Functions/Modules/Analog Input/BpodAnalogIn.m
+++ b/Functions/Modules/Analog Input/BpodAnalogIn.m
@@ -893,24 +893,24 @@ classdef BpodAnalogIn < handle
         end
         
         function scope_StartStop(obj, varargin)
-            % scope_StartStop() toggles data acquisition by the scope()
-            % GUI. It is called by a start button on the GUI, but it can also be 
-            % called from a user protocol file to start analog data logging with
-            % online monitoring.
+        % scope_StartStop   This function toggles data acquisition when using the oscilloscope functionality of the AnalogIn module. 
+        % The function is called by the start button on the oscilloscope GUI, but can also be called from a
+        % user protocol to start recording data with online monitoring via the GUI. 
+
+        % :param update_frequency: Update frequency, in seconds (s), for the oscilloscope GUI during data acquisition, defaults to 0.05 (50 ms)
+        % :type update_frequency: float, optional
+
             
             % Default GUI update time is 0.05s
             default_update_time = 0.05;
-            oscope_time = 0;
+            update_frequency = 0;
 
             ip = inputParser;
             valid_update_time = @(time) isfloat(time) && isscalar(time) && (time > 0);  % Update time must be a float, scalar, and greater than zero
-            valid_obj = @(x) isa(x, 'BpodAnalogIn'); % Have to also check obj is an instance of BpodAnalogIn
+            addOptional(ip, 'update_frequency', default_update_time, valid_update_time); % update_frequency is optional, if the passed value is invalid, the default is used
 
-            addRequired(ip, 'obj', valid_obj);  % instance is a required argument
-            addOptional(ip, 'oscope_time', default_update_time, valid_update_time); % oscope_time is optional, if the passed value is invalid, the default is used
-
-            parse(ip, obj, varargin{:});  % parse the args
-            oscope_time = ip.Results.oscope_time; % assuming all is well, grab the value from the parser
+            parse(ip, varargin{:});  % parse the args
+            update_frequency = ip.Results.update_frequency; % assuming all is well, grab the value from the parser
 
             scopeReady = 1;
             if ~isfield(obj.UIhandles, 'OscopeFig')
@@ -942,7 +942,7 @@ classdef BpodAnalogIn < handle
                     end
                     obj.UIdata.SweepPos = 1;
                     obj.startUSBStream;
-                    obj.Timer = timer('TimerFcn',@(h,e)obj.updatePlot(), 'ExecutionMode', 'fixedRate', 'Period', oscope_time);
+                    obj.Timer = timer('TimerFcn',@(h,e)obj.updatePlot(), 'ExecutionMode', 'fixedRate', 'Period', update_frequency);
                     start(obj.Timer);
                 else
                     stop(obj.Timer);


### PR DESCRIPTION
After our meeting yesterday, I figured this could be a useful feature since we had to modify the analog input module code which isn't optimal. 

This change will allow the user to pass a float >0 to scope_StartStop. The passed argument is verified using an inputParser which makes sure the argument is a float, scalar, and greater than zero. 

Due to the way inputParser works, we also have to check that the obj argument is also correct. Since scope_StartStop is a class function, the instance is automatically passed to the function. So, we check that the first parameter (the instance) is an instance of the analog input class. 

If the parameter is not passed, inputParser automatically sets the poll rate to the default. 
If the parameter is invalid (string, zero, negative, etc.) an error is raised. 