### PR TITLE
Make softcode function handling use feval

### DIFF
--- a/Functions/RunStateMachine.m
+++ b/Functions/RunStateMachine.m
@@ -437,7 +437,7 @@ function handle_soft_code(softCode)
 % Calls the current soft code handler function, passing it the SoftCode
 % received from the state machine
 global BpodSystem
-feval(BpodSystem.SoftCodeHandlerFunction, softCode)
+feval(BpodSystem.SoftCodeHandlerFunction, num2str(softCode))
 end
 
 function manualOverrideEvent = virtual_manual_override(overrideMessage)

--- a/Functions/RunStateMachine.m
+++ b/Functions/RunStateMachine.m
@@ -437,7 +437,7 @@ function handle_soft_code(softCode)
 % Calls the current soft code handler function, passing it the SoftCode
 % received from the state machine
 global BpodSystem
-eval([BpodSystem.SoftCodeHandlerFunction '(' num2str(softCode) ')'])
+feval(BpodSystem.SoftCodeHandlerFunction, softCode)
 end
 
 function manualOverrideEvent = virtual_manual_override(overrideMessage)


### PR DESCRIPTION
There's a small time improvement to the latency of soft-code function calls if `feval` is used instead of `eval`. Not much time saving, but it's for free.

Here are the numbers for running a function that only contains `global BpodSystem`, times in milliseconds.

- `eval()`: 0.4602 ms
- `feval()`: 0.0167 ms
- function handle: 0.0040 ms

![image](https://github.com/user-attachments/assets/c3206492-904a-4699-ab15-66adf0813b68)

There's more time saved if users use a function handle, which could be done like the example below (adapted [from the wiki](https://sanworks.github.io/Bpod_Wiki/function-reference/bpodsystem-fields/#softcodehandlerfunction)). If saving that 0.01 ms was super essential then it could be made so when `SoftCodeHandlerFunction` it configures itself to use a function handle (using `str2fun`), seems like a later thing though.

```matlab
% 1. (main protocol file): This single-state matrix sends a byte (3) back to the
% governing computer on state entry by setting a 'SoftCode' in Output Actions.
sma = NewStateMachine();
sma = AddState(sma, 'Name', 'State1', ...
    'Timer', 1,...
    'StateChangeConditions', {'Tup', 'exit'},...
    'OutputActions', {'SoftCode', 3});

% Part 2 (in main protocol file): This code specifies which file will handle the
% byte when it comes back.
% BpodSystem.SoftCodeHandlerFunction = 'SoftCodeHandler_Printout'; % can also work
BpodSystem.SoftCodeHandlerFunction = @SoftCodeHandler_Printout; % is a little bit faster

% Part 3 (separate file in protocol folder): This code handles the byte by
% printing it to the MATLAB command window.
function SoftCodeHandler_Printout(Byte)
disp(Byte);
```