### PR TITLE
Final fixes to liquid calibration overhaul

### DIFF
--- a/Bpod.m
+++ b/Bpod.m
@@ -115,6 +115,7 @@ bpod_setup;
 function bpod_setup
 % Runs BpodSystem's hardware and GUI setup methods.
 global BpodSystem
+BpodLib.BpodObject.setup.updatePathAndSettings(BpodSystem, 'verbose', true)
 BpodSystem.SetupHardware();
 BpodSystem.InitializeGUI();
 BpodSystem.Status.Initialized = true;

--- a/Functions/+BpodLib/+BpodObject/+setup/+compatibility/convertSettingsFolder.m
+++ b/Functions/+BpodLib/+BpodObject/+setup/+compatibility/convertSettingsFolder.m
@@ -84,7 +84,7 @@ for idx = 1:numel(files)
     movefile(sourceFile, destFile);
 end
 
-% renamefe Settings to Config
+% rename Settings to Config
 movefile(settingsFolder, fullfile(BpodSystem.Path.LocalDir, 'Config'));
 mkdir(settingsFolder);  % Recreate the Settings folder
 fid = fopen(fullfile(settingsFolder, 'files moved to Config folder.txt'), 'w');
@@ -100,6 +100,6 @@ fprintf(fid, 'This folder has had its contents moved Bpod Local/Config/ folder.\
 fclose(fid);
 Completed = 1;
 
-BpodLib.BpodObject.setup.updatePathAndSettings(BpodSystem)
+BpodLib.BpodObject.setup.updatePathAndSettings(BpodSystem, 'LocalDir', BpodSystem.Path.LocalDir);
 
 end

--- a/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
+++ b/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
@@ -73,6 +73,15 @@ end
 
 try
     BpodSystem.CalibrationTables.LiquidCal = BpodLib.calibration.liquid.io.load('BpodSystem', BpodSystem, 'LocalDir', LocalDir, 'type', 'statemachine');
+    if strcmp(BpodLib.calibration.liquid.utils.checkCOM(BpodSystem), 'no')
+        if p.Results.verbose
+            warning('BpodLib:Calibration:Liquid:CheckCOM', 'Calibration file COM port does not match current BpodSystem COM port.');
+            msg = msgbox(sprintf("Calibration file COM port (%s) does not match current BpodSystem COM port (%s). Please either initialise a multi-setup, re-run calibration, or verify that the correct COM port is being used and continue.", ...
+                BpodSystem.CalibrationTables.LiquidCal.metadata.COM, BpodLib.utils.getCurrentCOM(BpodSystem)), ...
+                'Calibration COM mismatch', 'warn', 'modal');
+            uiwait(msg)
+        end
+    end
 catch err
     if strcmp(err.identifier, 'BpodLib:LiquidCalibrationLoad:FileNotFound')
         BpodSystem.CalibrationTables.LiquidCal = [];

--- a/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
+++ b/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
@@ -119,6 +119,11 @@ for idx = 1:numel(configItems)
     fileName = [configItem '.mat'];
     configFilepath = fullfile(Path.SettingsDir, fileName);
     Path.(configItem) = configFilepath;
+
+    if strcmp(configItem, 'InputConfig')
+        continue
+    end
+    
     if ~isfile(Path.(configItem))
         copyfile(fullfile(ExamplesDir, 'Example Settings Files', fileName), Path.(configItem));
     end

--- a/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
+++ b/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
@@ -12,7 +12,7 @@ existingPath = BpodSystem.Path;
 
 %% -- Setup core pathing
 Path = struct();
-Path.BpodRoot = fileparts(which('Bpod'));
+Path.BpodRoot = BpodLib.path.getPath('root');
 Path.ParentDir = fileparts(Path.BpodRoot);
 if isempty(p.Results.LocalDir)
     Path.LocalDir = fullfile(Path.ParentDir, 'Bpod Local');

--- a/Functions/+BpodLib/+calibration/+liquid/+utils/checkCOM.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+utils/checkCOM.m
@@ -1,0 +1,29 @@
+function matchingCOM = checkCOM(BpodSystem)
+%matchingCOM = checkCOM(BpodSystem)
+% Check if the COM port in the calibration file matches the current BpodSystem COM port.
+
+matchingCOM = 'unknown';
+BpodSystemCOM = BpodLib.utils.getCurrentCOM(BpodSystem);
+LiquidCal = BpodSystem.CalibrationTables.LiquidCal;
+
+if isempty(LiquidCal)
+    % LiquidCal failed to load for some reason
+    return
+end
+
+if isa(LiquidCal, 'struct')
+    % Is a legacy system, no ability to check COM
+    return
+end
+
+if ~isfield(LiquidCal.metadata, 'COM')
+    return
+end
+
+if strcmp(LiquidCal.metadata.COM, BpodSystemCOM)
+    matchingCOM = 'yes';
+else
+    matchingCOM = 'no';
+end
+
+end

--- a/Functions/+BpodLib/+calibration/+liquid/LiquidCalibratorUI.m
+++ b/Functions/+BpodLib/+calibration/+liquid/LiquidCalibratorUI.m
@@ -325,7 +325,7 @@ methods
         % Deliver liquid
         [valveNames, pulseDurations_ms] = obj.PendingMeasurements.getPending();
         assert(numel(valveNames) > 0, 'There must be pending values to calibrate')
-        Completed = BpodLib.calibration.liquid.RunRewardCalibration(obj.BpodSystem, str2double(get(obj.GUIHandles.nPulsesEdit, 'string')), valveNames, pulseDurations_ms * 1000, 'PulseInterval', .2);
+        Completed = BpodLib.calibration.liquid.RunRewardCalibration(obj.BpodSystem, str2double(get(obj.GUIHandles.nPulsesEdit, 'string')), valveNames, pulseDurations_ms / 1000, 'PulseInterval', .2);
         if Completed
             % -- Create GUI for entering measurements
             allValveNames = fields(obj.PendingMeasurements.data);

--- a/Functions/+BpodLib/+calibration/+liquid/RunRewardCalibration.m
+++ b/Functions/+BpodLib/+calibration/+liquid/RunRewardCalibration.m
@@ -19,6 +19,7 @@ function Completed = RunRewardCalibration(BpodSystem, nPulses, TargetValves, Pul
 p = inputParser();
 p.addParameter('PulseInterval', 0.2, @isnumeric);
 p.addParameter('PulseSetPause', 0.5, @isnumeric);
+p.addParameter('verbose', true)
 p.parse(varargin{:})
 
 Completed = 0;
@@ -34,11 +35,17 @@ for x = 1:length(PulseDurations)
 end
 
 % Build valve testing information
+if p.Results.verbose
+    fprintf('Liquid Calibration with .\n')
+end
 data = struct('name', [], 'outputaction', [], 'type', []);
 ValvePhysicalAddress = 2.^(0:7);
 nValves = length(TargetValves);
 for idx = 1:nValves
     valveName = TargetValves{idx};
+    if p.Results.verbose
+        fprintf('\t%s for %.1f ms\n', valveName, PulseDurations(idx) / 1000)
+    end
     if strcmp(valveName(1:5), 'Valve')
         data(idx).name = valveName;
         valveID = str2double(valveName(6));
@@ -52,6 +59,10 @@ for idx = 1:nValves
     else
         error('BpodLib:LiquidCalibration:UnrecognisedValveName', 'Valve %s does not meet expected format requirement.', valveName)
     end
+end
+
+if p.Results.verbose
+    fprintf('%s start\n', valveName, PulseDurations(idx) / 1000)
 end
 
 % Create the set of pulses to be tested out

--- a/Functions/+BpodLib/+path/getPath.m
+++ b/Functions/+BpodLib/+path/getPath.m
@@ -32,6 +32,18 @@ p.parse(varargin{:})
 
 BpodSystem = p.Results.BpodSystem;
 
+if strcmp(target, 'root')
+    path = fileparts(which('Bpod'));
+    [~, parentDir] = fileparts(path);
+    if strcmp(parentDir, 'Internal Functions')
+        path = fileparts(fileparts(path)); % go up two levels if in Internal Functions
+    end
+    assert(isfolder(path), 'BpodLib:Path:RootNotFound', 'Bpod root directory not found. Ensure Bpod is installed correctly.');
+    [~, parentDir] = fileparts(path);
+    assert(strcmpi(parentDir, 'Bpod_Gen2'), 'BpodLib:Path:RootNotBpod', 'Bpod root directory is not named "Bpod_Gen2". Ensure Bpod is installed correctly.');
+    return
+end
+
 assert(~isempty(p.Results.BpodSystem) || ~isempty(p.Results.LocalDir), 'BpodLib:Path:MissingPathReference', 'Either BpodSystem or LocalDir must be provided to getPath.')
 
 if ~isempty(p.Results.setuptype)
@@ -77,9 +89,8 @@ switch lower(target)
             return
         end
         path = fullfile(BpodLib.path.getPath('config', varargin{:}));
-    case 'root'
-        % ? should this check Path to see if there are multiple Bpod.m files
-        path = fileparts(which('Bpod'));
+    % case 'root'
+        % this is handled before anything else since it's fixed
     case 'settings'
         LocalDir = BpodLib.path.getPath('local', varargin{:});
         if BpodLib.path.compatibility.isLegacySettings(LocalDir)

--- a/Functions/@BpodObject/BpodObject.m
+++ b/Functions/@BpodObject/BpodObject.m
@@ -174,7 +174,7 @@ classdef BpodObject < handle
             % Initialize paths
             obj.Path.BpodRoot = BpodLib.path.getPath('root');
             obj.Path.LocalDir = fullfile(fileparts(obj.Path.BpodRoot), 'Bpod Local');
-            BpodLib.BpodObject.setup.updatePathAndSettings(obj, 'verbose', p.Results.verbose);
+            % BpodLib.BpodObject.setup.updatePathAndSettings(obj, 'verbose', p.Results.verbose);
 
             if p.Results.verbose
                 obj.BpodSplashScreen(1);

--- a/Functions/@BpodObject/BpodObject.m
+++ b/Functions/@BpodObject/BpodObject.m
@@ -172,6 +172,8 @@ classdef BpodObject < handle
             end
             
             % Initialize paths
+            obj.Path.BpodRoot = BpodLib.path.getPath('root');
+            obj.Path.LocalDir = fullfile(fileparts(obj.Path.BpodRoot), 'Bpod Local');
             BpodLib.BpodObject.setup.updatePathAndSettings(obj, 'verbose', p.Results.verbose);
 
             if p.Results.verbose

--- a/Functions/@BpodObject/Connect2BpodSM.m
+++ b/Functions/@BpodObject/Connect2BpodSM.m
@@ -141,8 +141,8 @@ if obj.SerialPort.UsePsychToolbox == 0 && verLessThan('matlab', '9.7')
 end
 
 % Finish setup
-obj.SystemSettings.LastCOMPort = Ports{thisPortIndex};
-obj.SaveSettings;
+% obj.SystemSettings.LastCOMPort = Ports{thisPortIndex};
+% obj.SaveSettings;
 obj.EmulatorMode = 0;
 if obj.Status.Verbose
     obj.BpodSplashScreen(2);

--- a/Tests/BpodLib/BpodObject/setup/test_SettingsAndFiles.m
+++ b/Tests/BpodLib/BpodObject/setup/test_SettingsAndFiles.m
@@ -11,7 +11,7 @@ function setup(testCase)
     % Setup test data that will be used for all tests
     rootPath = tempname;  % Generate a unique temporary directory
     testCase.TestData.rootPath = rootPath;
-    testCase.TestData.BpodPath = fileparts(which('Bpod'));
+    testCase.TestData.BpodPath = BpodLib.path.getPath('root');
     mkdir(testCase.TestData.rootPath)
     LocalDir = fullfile(rootPath, 'Bpod Local');
     testCase.TestData.LocalDir = LocalDir;

--- a/Tests/BpodLib/BpodObject/setup/test_legacySetup.m
+++ b/Tests/BpodLib/BpodObject/setup/test_legacySetup.m
@@ -10,7 +10,7 @@ function setup(testCase)
     % Setup test data that will be used for all tests
     rootPath = tempname;  % Generate a unique temporary directory
     testCase.TestData.rootPath = rootPath;
-    testCase.TestData.BpodPath = fileparts(which('Bpod'));
+    testCase.TestData.BpodPath = BpodLib.path.getPath('root');
     mkdir(testCase.TestData.rootPath)
     LocalDir = fullfile(rootPath, 'Bpod Local');
     testCase.TestData.LocalDir = LocalDir;

--- a/Tests/BpodLib/BpodObject/setup/test_legacySetup.m
+++ b/Tests/BpodLib/BpodObject/setup/test_legacySetup.m
@@ -87,7 +87,7 @@ function test_conversionCongruence(testCase)
     % Now test to see if Bpod Local/ and Bpod Local New/ are the same
     convertedFiles = dir(fullfile(testCase.TestData.BpodSystem.Path.LocalDir, 'Config/*.*'));
     newFiles = dir(fullfile(BpodSystemNew.Path.LocalDir, 'Config/*.*'));
-    testCase.verifyEqual(numel(convertedFiles) - 1, numel(newFiles), 'Number of files in Config folder after conversion does not match the new setup.');
+    testCase.verifyEqual(numel(convertedFiles) - 2, numel(newFiles), 'Number of files in Config folder after conversion does not match the new setup.');
     for idx = 1:numel(newFiles)
         if convertedFiles(idx).isdir
             continue

--- a/Tests/BpodLib/calibration/liquid/test_dataWarning.m
+++ b/Tests/BpodLib/calibration/liquid/test_dataWarning.m
@@ -10,7 +10,7 @@ function setup(testCase)
 
     % Create a mock ValveDataManager class, using the file used at fresh Bpod startup
     valveManager = BpodLib.calibration.liquid.ValveDataManagerClass();
-    rootPath = fileparts(which('Bpod'));
+    rootPath = BpodLib.path.getPath('root');
     filePath = fullfile(rootPath, 'Examples/Example Calibration Files/LiquidCalibration.json');
     valveManager.loadData(filePath)
     testCase.TestData.mockValveDataManager = valveManager;

--- a/Tests/BpodLib/calibration/liquid/test_liquidutils.m
+++ b/Tests/BpodLib/calibration/liquid/test_liquidutils.m
@@ -8,8 +8,7 @@ function setup(testCase)
     localdir = fullfile(testCase.TestData.rootPath, 'Bpod Local');
     mkdir(localdir)
     
-    mockBpod = struct();
-    mockBpod.SerialPort.PortName = 'COM13';
+    mockBpod = BpodLib.BpodObject.MockBpodObject('COM13');
     mockBpod.Path.LocalDir = localdir;
     testCase.TestData.mockBpod = mockBpod;
 
@@ -39,4 +38,36 @@ function test_suggestDuration(testCase)
     testCase.verifyEqual(suggestedDuration, 51.128, 'AbsTol', 0.001); % Adjust tolerance as needed
 
     % todo: build out this test for the other cases
+end
+
+function test_checkCOM(testCase)
+    % Test the checkCOM function with a mock BpodSystem
+    mockBpod = testCase.TestData.mockBpod;
+    LiquidCal = BpodLib.calibration.liquid.ValveDataManagerClass();
+    mockBpod.CalibrationTables.LiquidCal = LiquidCal;
+    LiquidCal.metadata = struct();
+
+    % Create a mock LiquidCal with a matching COM port
+    LiquidCal.metadata.COM = 'COM13';
+    mockBpod.CalibrationTables.LiquidCal = LiquidCal;
+
+    matchingCOM = BpodLib.calibration.liquid.utils.checkCOM(mockBpod);
+    testCase.verifyEqual(matchingCOM, 'yes');
+
+    % Now change the COM port and check again
+    LiquidCal.metadata.COM = 'COM14';
+    mockBpod.CalibrationTables.LiquidCal = LiquidCal;
+
+    matchingCOM = BpodLib.calibration.liquid.utils.checkCOM(mockBpod);
+    testCase.verifyEqual(matchingCOM, 'no');
+
+    % Test with no LiquidCal
+    mockBpod.CalibrationTables.LiquidCal = [];
+    matchingCOM = BpodLib.calibration.liquid.utils.checkCOM(mockBpod);
+    testCase.verifyEqual(matchingCOM, 'unknown');
+
+    % Test with a legacy LiquidCal (struct without metadata)
+    mockBpod.CalibrationTables.LiquidCal = struct();
+    matchingCOM = BpodLib.calibration.liquid.utils.checkCOM(mockBpod);
+    testCase.verifyEqual(matchingCOM, 'unknown');
 end

--- a/Tests/BpodLib/path/test_getPath.m
+++ b/Tests/BpodLib/path/test_getPath.m
@@ -75,7 +75,7 @@ function test_arguments_vs_auto(testCase)
         for localDir = LocalDirs
             for setupType = SetupTypes
                 for bpod = Bpods
-                    if isempty(bpod{1}) && isempty(localDir{1})
+                    if isempty(bpod{1}) && isempty(localDir{1}) && ~strcmp(target{1}, 'root')
                         % Argument requires either BpodSystem or LocalDir
                         testCase.verifyError(@() BpodLib.path.getPath(target{1}, 'setuptype', setupType{1}), 'BpodLib:Path:MissingPathReference', sprintf('Should throw an error when both BpodSystem and LocalDir are empty for target "%s".', target{1}));
                         continue


### PR DESCRIPTION
# Final fixes to liquid calibration code
This PR address existing issues from #26 

- [x] All behavior ports are disabled by default when /Bpod Local/ is generated, which means that the example protocols don't "just work". Revert to the old default with ports 1-3 enabled.
- [x] If multi-setup has not been initialized, a mismatch between the current COM port and the one in the calibration file should result in a warning modal asking the user to initialize multi-setup or re-run calibration with the current machine. Currently there is no error so a state machine on COM4 will use calibration files created with a machine on COM3.
- [ ] With multi-setup initialized, removing a datapoint from the calibration table persists if the calibration GUI is closed and re-opened, but closing the Bpod console and re-opening it restores the datapoint. The datapoint should be removed from the .json file. This does not appear to be an issue before multi-setup is initialized. The underlying issue may be related to the next issue.
- [x] When BpodLib.multi.createMultiSetup(BpodSystem) was called for COM3, /Config/Machine-COM3/ was created with all of the default settings files. However on the first run of a machine on COM4, /Config/Machine-COM4/ was created with only LiquidCalibration.json. The other settings files are missing. The COM4 instance appears to be using /Config/Machine-EMU/ to populate things like BpodSystem.Path.InputConfig.
- [x] If a legacy /Bpod Local/ folder exists, the following error is encountered on run: Dot indexing is not supported for variables of this type. Error in BpodLib.multi.isMultiSetup (line 20). The issue is that p.Results.BpodSystem.Path.LocalDir is empty - BpodSystem.Path has not been populated yet.

