### PR TITLE
Use getPath for sound calibration file pathing

### DIFF
--- a/Functions/Calibration/Sound/SoundCalibrationManager.m
+++ b/Functions/Calibration/Sound/SoundCalibrationManager.m
@@ -264,7 +264,7 @@ else
     BpodSystem.PluginObjects.SoundServer = PsychToolboxAudio;
 end
 
-[FileName,PathName] = uiputfile(fullfile(BpodSystem.Path.LocalDir, 'Calibration Files', 'SoundCalibration.mat'), 'Save Sound Calibration File');
+[FileName, PathName] = uiputfile(fullfile(BpodLib.path.getPath('liquidcalibration', BpodSystem), 'SoundCalibration.mat'), 'Save Sound Calibration File');
 
 handles.filename = fullfile(PathName,FileName);
 

--- a/Functions/Calibration/Sound/TestSoundManager.m
+++ b/Functions/Calibration/Sound/TestSoundManager.m
@@ -207,7 +207,7 @@ global BpodSystem
 % hObject    handle to file (see GCBO)
 % eventdata  reserved - to be defined in a future version of MATLAB
 % handles    structure with handles and user data (see GUIDATA)
-[FileName,PathName] = uigetfile(fullfile(BpodSystem.Path.LocalDir, 'Calibration Files'));
+[FileName, PathName] = uigetfile(BpodLib.path.getPath('liquidcalibration', BpodSystem));
 if FileName ~= 0
     handles.calfile = fullfile(PathName,FileName);
     set(handles.filename_edit, 'String', handles.calfile);

--- a/Functions/Firmware Update/LoadBpodFirmware.m
+++ b/Functions/Firmware Update/LoadBpodFirmware.m
@@ -425,6 +425,7 @@ classdef LoadBpodFirmware < handle
             try
                 bpodPath = fileparts(which('Bpod'));
                 parentDir = fileparts(bpodPath);
+                % todo: fix this pathing reference
                 settingsDir = fullfile(parentDir, 'Bpod Local', 'Settings');
                 data = load(fullfile(settingsDir, 'ModuleUSBConfig.mat'));
                 moduleUSBConfig = data.ModuleUSBConfig(1);


### PR DESCRIPTION
Fixes sound calibration file pathing (untested).

- [ ] `LoadBpodFirmware` ModuleUSBConfig.mat requires solution