### PR TITLE
Cleanup of +BpodLib

### DIFF
--- a/Functions/+BpodLib/+BpodObject/+setup/+compatibility/convertSettingsFolder.m
+++ b/Functions/+BpodLib/+BpodObject/+setup/+compatibility/convertSettingsFolder.m
@@ -1,13 +1,46 @@
-function Completed = convertSettingsFolder(BpodSystem, varargin)
-% Completed = convertSettingsFolder(BpodSystem)
-% Convert a Bpod Local folder with Calibration Files/ and Settings/ into only Config/
+function completed = convertSettingsFolder(BpodSystem, varargin)
+% Convert Calibration Files/ and Settings/ into Config/
+% completed = convertSettingsFolder(BpodSystem, _)
+%
+% Arguments
+% ----------
+% BpodSystem : BpodObject
+%
+% Keyword Arguments
+% -----------------
+% verbose : logical (default=true)
+%     Whether to display progress messages
+%
+% Returns
+% -------
+% completed : int
+%     Returns 1 if conversion was successful, 0 otherwise
 
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 p = inputParser();
 p.addParameter('verbose', true)
 p.parse(varargin{:})
 
-Completed = 0;
+completed = 0;
 
 if verLessThan('matlab', '9.1')
     warning('Your MATLAB version (%s) is older than R2016b (9.1). New liquid calibration format requires jsonencode/jsondecode from R2016b.', version);
@@ -17,9 +50,13 @@ if verLessThan('matlab', '9.1')
     return
 end
 
+% Set file paths
 calibrationFolderpath = fullfile(BpodSystem.Path.LocalDir, 'Calibration Files');
+settingsFolderpath = fullfile(BpodSystem.Path.LocalDir, 'Settings');
 oldFilepath = fullfile(calibrationFolderpath, 'LiquidCalibration.mat');
-newFilepath = fullfile(calibrationFolderpath, 'LiquidCalibration.json');
+newFilepath = fullfile(calibrationFolderpath, 'LiquidCalibration.json'); % the intermediate location of the new liquid calibration file
+
+configFolderpath = BpodLib.path.getPath('config', BpodSystem, 'setuptype', 'single');
 
 % Check if the conversion script has to be run
 previouslyCompleted = false;
@@ -31,6 +68,9 @@ end
 if ~isfile(oldFilepath)
     previouslyCompleted = true;
 end
+if isfolder(configFolderpath)
+    previouslyCompleted = true;
+end
 
 if previouslyCompleted
     warning('Conversion script is detected as already having been run, run cancelled.')
@@ -39,10 +79,10 @@ end
 
 BpodLib.BpodObject.setup.compatibility.saveSettingsBackup(BpodSystem.Path.LocalDir, 'verbose', p.Results.verbose);
 
+%% Convert liquid calibration file
 % Save the new format
 try
     BpodLib.calibration.liquid.compatibility.convertMAT2JSON(BpodSystem, oldFilepath, newFilepath);
-    Completed = 1;
 catch ME
     disp('Conversion of liquid calibration failed.')
     rethrow(ME)
@@ -56,22 +96,14 @@ if p.Results.verbose
     disp('Successfully converted LiquidCalibration.mat to LiquidCalibration.json');
 end
 
-
 %% Move files from Calibration Files to Settings
-if ~isfile(fullfile(BpodSystem.Path.LocalDir, 'Calibration Files/LiquidCalibration.json'))
-    return
-end
 
 if BpodLib.multi.isMultiSetup(BpodSystem)
     error('BpodLib:convertSettingsFolder:MultiSetup', 'Legacy liquid calibration detected but multi-setup detected. This is not supported, liquid calibration has to be converted to the new format first.');
 end
 
-% Move contents of Calibration Files/ to Settings/
-calibrationFolder = fullfile(BpodSystem.Path.LocalDir, 'Calibration Files');
-settingsFolder = fullfile(BpodSystem.Path.LocalDir, 'Settings');
-
 % Move all files from Calibration Files to Settings
-files = dir(fullfile(calibrationFolder, '*.*'));
+files = dir(fullfile(calibrationFolderpath, '*.*'));
 for idx = 1:numel(files)
     if files(idx).isdir
         continue
@@ -79,27 +111,32 @@ for idx = 1:numel(files)
     if strcmp(files(idx).name, 'OLD LiquidCalibration.mat')
         continue
     end
-    sourceFile = fullfile(calibrationFolder, files(idx).name);
-    destFile = fullfile(settingsFolder, files(idx).name);
+    sourceFile = fullfile(calibrationFolderpath, files(idx).name);
+    destFile = fullfile(settingsFolderpath, files(idx).name);
     movefile(sourceFile, destFile);
 end
 
-% rename Settings to Config
-movefile(settingsFolder, fullfile(BpodSystem.Path.LocalDir, 'Config'));
-mkdir(settingsFolder);  % Recreate the Settings folder
-fid = fopen(fullfile(settingsFolder, 'files moved to Config folder.txt'), 'w');
-fprintf(fid, 'This folder has had its contents moved to the Bpod Local/Config/ folder.\nThis conversion was performed: %s\nThis folder can be deleted.', BpodLib.utils.isotime());
-fclose(fid);
+% Move Settings/ to Config/
+movefile(settingsFolderpath, configFolderpath);
+
+% Leave files pointing to new file locations
+mkdir(settingsFolderpath);  % Recreate the Settings folder
+createInfoFile(fullfile(settingsFolderpath, 'files moved to Config folder.txt'), BpodSystem.Path.LocalDir)
+createInfoFile(fullfile(calibrationFolderpath, 'files moved to Config folder.txt'), BpodSystem.Path.LocalDir)
 
 % Attach the new file into LiquidCal
 BpodSystem.CalibrationTables.LiquidCal = BpodLib.calibration.liquid.io.load('BpodSystem', BpodSystem, 'type', 'statemachine');
 
-% Place a note in the Calibration Files folder
-fid = fopen(fullfile(calibrationFolder, 'calibration files have moved.txt'), 'w');
-fprintf(fid, 'This folder has had its contents moved Bpod Local/Config/ folder.\nThis conversion was performed: %s\nThis folder can be deleted.', BpodLib.utils.isotime());
-fclose(fid);
-Completed = 1;
-
 BpodLib.BpodObject.setup.updatePathAndSettings(BpodSystem, 'LocalDir', BpodSystem.Path.LocalDir);
+completed = 1;
 
+end
+
+function createInfoFile(filepath, newLocalDir)
+fid = fopen(filepath, 'w');
+if fid == -1
+    error('Could not create info file at: %s', filepath);
+end
+fprintf(fid, 'This folder has had its contents moved to %s/Config/ folder.\nThis conversion was performed: %s\nThis folder can be deleted.', newLocalDir, BpodLib.utils.isotime());
+fclose(fid);
 end

--- a/Functions/+BpodLib/+BpodObject/+setup/+compatibility/saveSettingsBackup.m
+++ b/Functions/+BpodLib/+BpodObject/+setup/+compatibility/saveSettingsBackup.m
@@ -1,9 +1,41 @@
 function saveSettingsBackup(LocalDir, varargin)
-%saveSettingsBackup(LocalDir)
+% Save timestamped folder of Settings/ and Calibration Files/ contents
+% saveSettingsBackup(LocalDir, _)
+%
+% Arguments
+% ---------
+% LocalDir : char
+%     Descriptor
+%
+% Keyword Arguments
+% -----------------
+% verbose : logical (default=true)
+%     Whether to display messages in Command Window.
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 p = inputParser();
 p.addParameter('verbose', true, @islogical);
 p.parse(varargin{:});
+
 if ~isfolder(LocalDir)
     error('LocalDir must be a valid directory path.');
 end

--- a/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
+++ b/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
@@ -1,7 +1,44 @@
 function updatePathAndSettings(BpodSystem, varargin)
-% updatePathAndSettings(BpodSystem)
-% Set up paths to folders and prepare folders.
-% This is ran at Bpod startup and when file structure is changed during multi-setup initialization.
+% Update Bpod system paths and settings configuration.
+% updatePathAndSettings(BpodSystem, _)
+%
+% Sets up paths to folders and prepares folder structure. This function is called:
+% - At Bpod startup
+% - When file structure is changed during multi-setup initialization
+%
+% Modifies BpodSystem's Path property
+%
+% Parameters
+% ----------
+% BpodSystem : struct
+%     The Bpod system object
+%
+% Keyword Arguments
+% -----------------
+% LocalDir : char (default='')
+%     Path to Bpod Local directory. If empty, uses default location.
+% verbose : logical (default=false)
+%     Whether to display progress messages.
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 p = inputParser;
 p.addParameter('LocalDir', '');
@@ -14,12 +51,15 @@ existingPath = BpodSystem.Path;
 Path = struct();
 Path.BpodRoot = BpodLib.path.getPath('root');
 Path.ParentDir = fileparts(Path.BpodRoot);
+
 if isempty(p.Results.LocalDir)
     Path.LocalDir = fullfile(Path.ParentDir, 'Bpod Local');
 else
     Path.LocalDir = p.Results.LocalDir;
 end
 LocalDir = Path.LocalDir;
+
+% SettingsDir will be Config/ unless setup uses legacy folder structure
 Path.SettingsDir = BpodLib.path.getPath('settings', BpodSystem, 'LocalDir', LocalDir);
 
 if ~isfolder(Path.LocalDir)
@@ -31,24 +71,28 @@ end
 
 %% -- Configure user-settable BpodSettings paths
 ExamplesDir = fullfile(Path.BpodRoot, 'Examples');
+
+% Load system settings if they exist
 if isfile(fullfile(Path.SettingsDir, 'BpodSettings.mat'))
     BpodSystem.SystemSettings = load(fullfile(Path.SettingsDir, 'BpodSettings.mat'), 'BpodSettings').BpodSettings;
 else
     BpodSystem.SystemSettings = struct();
 end
 
-% Specify user paths only if they are set in BpodSettings.mat and also exist
+% Process user folders from settings
 userFolders = {'ProtocolFolder', 'DataFolder', 'BcontrolRootFolder'};
 for idx = 1:numel(userFolders)
-    foldertypename = userFolders{idx};
-    Path.(foldertypename) = '';
-    if isfield(BpodSystem.SystemSettings, foldertypename)
-        if isfolder(BpodSystem.SystemSettings.(foldertypename))
-            Path.(foldertypename) = BpodSystem.SystemSettings.(foldertypename);
+    folderType = userFolders{idx};
+    Path.(folderType) = '';
+    if isfield(BpodSystem.SystemSettings, folderType)
+        if isfolder(BpodSystem.SystemSettings.(folderType))
+            Path.(folderType) = BpodSystem.SystemSettings.(folderType);
         end
     end
 end
 
+% Add ExpertPort to path if Bcontrol exists
+% todo: this is untested
 if isfolder(Path.BcontrolRootFolder)
     ExperPortFolder = fullfile(Path.BcontrolRootFolder, 'ExperPort');
     if isfolder(ExperPortFolder)
@@ -119,10 +163,6 @@ for idx = 1:numel(configItems)
     fileName = [configItem '.mat'];
     configFilepath = fullfile(Path.SettingsDir, fileName);
     Path.(configItem) = configFilepath;
-
-    if strcmp(configItem, 'InputConfig')
-        continue
-    end
     
     if ~isfile(Path.(configItem))
         copyfile(fullfile(ExamplesDir, 'Example Settings Files', fileName), Path.(configItem));
@@ -131,11 +171,11 @@ for idx = 1:numel(configItems)
     if strcmp(configItem, {'ModuleUSBConfig'})
         continue
     elseif strcmp(configItem, 'InputConfig')
-        loaded_item = load(Path.(configItem), 'BpodInputConfig');
-        BpodSystem.InputsEnabled = loaded_item.BpodInputConfig;
+        loadedItem = load(Path.(configItem), 'BpodInputConfig');
+        BpodSystem.InputsEnabled = loadedItem.BpodInputConfig;
     elseif strcmp(configItem, 'SyncConfig')
-        loaded_item = load(Path.(configItem), 'BpodSyncConfig');
-        BpodSystem.SyncConfig = loaded_item.BpodSyncConfig;
+        loadedItem = load(Path.(configItem), 'BpodSyncConfig');
+        BpodSystem.SyncConfig = loadedItem.BpodSyncConfig;
     else
         error('Unknown config item: %s', configItem);
     end
@@ -146,6 +186,7 @@ Path.FlexConfig = fullfile(Path.SettingsDir, 'FlexConfig.mat');
 %% -- Add dynamic paths to Path
 % These are set when a protocol is run, so copy them from existingPath if available.
 if ~isempty(existingPath)
+    % Copy standard dynamic paths
     dynamicNames = {'Settings', 'CurrentDataFile', 'CurrentProtocol'};
     for idx = 1:numel(dynamicNames)
         dynamicName = dynamicNames{idx};
@@ -156,7 +197,7 @@ if ~isempty(existingPath)
         end
     end
     
-    % Add paths in existingPath that aren't in Path
+    % Add any additional paths from existingPath
     dynamicNames = fieldnames(existingPath);
     for idx = 1:numel(dynamicNames)
         dynamicName = dynamicNames{idx};

--- a/Functions/+BpodLib/+BpodObject/MockBpodObject.m
+++ b/Functions/+BpodLib/+BpodObject/MockBpodObject.m
@@ -1,3 +1,25 @@
+% Mock BpodObject for use in unit testing
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
 classdef MockBpodObject < handle
 properties
     SerialPort
@@ -16,7 +38,7 @@ properties
 end
 methods
     function obj = MockBpodObject(varargin)
-
+        % obj = MockBpodObject(_)
         p = inputParser();
         p.addRequired('comport')
         p.addParameter('verbose', false, @islogical);

--- a/Functions/+BpodLib/+calibration/+liquid/+compatibility/conversionscript.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+compatibility/conversionscript.m
@@ -1,5 +1,27 @@
-function Completed = conversionscript(BpodSystem, varargin)
+function completed = conversionscript(BpodSystem, varargin)
 % Convert the Liquid Calibration .mat file to the new .json format
 
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
+% todo: candidate for deletion? 
+
 % The conversion script functionality is now an essential part of folder settings
-Completed = BpodLib.BpodObject.setup.compatibility.convertSettingsFolder(BpodSystem, varargin{:});
+completed = BpodLib.BpodObject.setup.compatibility.convertSettingsFolder(BpodSystem, varargin{:});

--- a/Functions/+BpodLib/+calibration/+liquid/+compatibility/convertFormat.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+compatibility/convertFormat.m
@@ -1,19 +1,45 @@
-function valveManager = convertFormat(LiquidCal)
-% Convert LiquidCal structure to ValveDataManagerClass
+function LiquidCal_obj = convertFormat(LiquidCal_struct)
+% Convert LiquidCal_struct structure to ValveDataManagerClass
+% LiquidCal_obj = convertFormat(LiquidCal_struct)
 %
-% :param LiquidCal: the LiquidCalibration structure
-% :type LiquidCal: struct
-% :return: the ValveDataManager object
-% :rtype: BpodLib.calibration.liquid.ValveDataManagerClass
+% Arguments
+% ---------
+% LiquidCal_struct : struct
+%     LiquidCal_struct : the LiquidCalibration structure
+%
+% Returns
+% -------
+% LiquidCal_obj : BpodLib.calibration.liquid.ValveDataManagerClass
+%     ValveDataManager object
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 % Create data object and add measurements
-valveManager = BpodLib.calibration.liquid.ValveDataManagerClass();
-nValves = numel(LiquidCal);
+LiquidCal_obj = BpodLib.calibration.liquid.ValveDataManagerClass();
+nValves = numel(LiquidCal_struct);
 for valveNumber = 1:nValves
     % Original data stores valves in nonscalar structure
     valveName = sprintf('Valve%i', valveNumber);
-    valveData = valveManager.createValve(valveName);
-    originalData = LiquidCal(valveNumber);
+    valveData = LiquidCal_obj.createValve(valveName);
+    originalData = LiquidCal_struct(valveNumber);
     nMeasurements = size(originalData.Table, 1);
     for measurementIdx = 1:nMeasurements
         valveData.addMeasurement(originalData.Table(measurementIdx, 1), originalData.Table(measurementIdx, 2));

--- a/Functions/+BpodLib/+calibration/+liquid/+compatibility/convertMAT2JSON.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+compatibility/convertMAT2JSON.m
@@ -1,29 +1,51 @@
-function convertMAT2JSON(BpodSystem, sourcepath, savepath)
+function convertMAT2JSON(BpodSystem, sourcePath, savePath)
 % Convert a LiquidCalibration.mat file to a LiquidCalibration.json file
-% :param sourcepath: the path to the LiquidCalibration.mat file
-% :type sourcepath: char
-% :param savepath: the path to save the .json file
-% :type savepath: char
+% convertMAT2JSON(BpodSyste, sourcePath, savePath)
+%
+% Prior to version 1.9.0 liquid calibration data was stored in a .mat file.
+% This function converts the .mat to .json
+%
+% Arguments
+% ---------
+% BpodSystem : BpodObject
+% sourcePath : char
+%     Path to the LiquidCalibration.mat file
+% savePath : char
+%     Path to save the .json file
 
 %{
-Prior to version 1.X.X, liquid calibration data was stored in a .mat file.
-This function converts the .mat file to a .json file for compatibility with the new format.
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %}
 
-[~, ~, ext] = fileparts(sourcepath);
-
+[~, ~, ext] = fileparts(sourcePath);
 assert(strcmp(ext, '.mat'), 'File must be a .mat file');
-LiquidCal = load(sourcepath, 'LiquidCal').LiquidCal;
 
-nValves = numel(LiquidCal);
+LiquidCal_struct = load(sourcePath, 'LiquidCal').LiquidCal;
+
+nValves = numel(LiquidCal_struct);
 if nValves ~= 8
     warning('BpodLib:ValveDataManagerClass:UnexpectedValveNumber', '8 valves expected but %i found. User-modified liquid calibration data likely.', nValves);
 end
 
-valveManager = BpodLib.calibration.liquid.compatibility.convertFormat(LiquidCal);
+LiquidCal_obj = BpodLib.calibration.liquid.compatibility.convertFormat(LiquidCal_struct);
 
-valveDatas = valveManager.createSaveData();
-currentCOM = BpodLib.utils.getCurrentCOM(BpodSystem);
-valveDatas.metadata.COM = currentCOM;
-BpodLib.calibration.liquid.io.save(valveDatas, 'filepath', savepath, 'BpodSystem', BpodSystem);
+LiquidCalSaveData = LiquidCal_obj.createSaveData();
+LiquidCalSaveData.metadata.COM = BpodLib.utils.getCurrentCOM(BpodSystem);
+BpodLib.calibration.liquid.io.save(LiquidCalSaveData, 'filepath', savePath, 'BpodSystem', BpodSystem);
 end

--- a/Functions/+BpodLib/+calibration/+liquid/+compatibility/convertToOldFormat.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+compatibility/convertToOldFormat.m
@@ -1,29 +1,59 @@
-function LiquidCal = convertToOldFormat(ValveDataManager)
-% Save ValveDataManager as the old format
+function LiquidCal_struct = convertToOldFormat(LiquidCal_obj)
+% Convert a LiquidCal object to the legacy struct format
+% LiquidCal_struct = convertToOldFormat(LiquidCal_obj)
+%
+% Arguments
+% ---------
+% LiquidCal_obj : BpodLib.calibration.liquid.ValveDataManagerClass
+%
+% Returns
+% -------
+% LiquidCal_struct : struct
+%     Same data but different format
 
-LiquidCal = struct('Table', [], 'Coeffs', [], 'LastDateModified', []);
+%{
+----------------------------------------------------------------------------
 
-valveNames = ValveDataManager.getValveNames();
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
+LiquidCal_struct = struct('Table', [], 'Coeffs', [], 'LastDateModified', []);
+
+valveNames = LiquidCal_obj.getValveNames();
 assert(numel(valveNames) == 8)
 
-savetimes = nan(1, 8);
+saveTimes = nan(1, 8);
 
 for x = 1:8
-    Valve = ValveDataManager.getValve(x);
+    Valve = LiquidCal_obj.getValve(x);
     Table = [Valve.Durations, Valve.Amounts];
     [~, nCols] = size(Table);
     if ~ismember(nCols, [0, 2])
         error('Table is not working as expected.')
     end
-    LiquidCal(x).Table = Table;
-    LiquidCal(x).Coeffs = Valve.Coeffs;
+    LiquidCal_struct(x).Table = Table;
+    LiquidCal_struct(x).Coeffs = Valve.Coeffs;
     ldm = Valve.LastDateModified;
     if ~isempty(ldm)
-        savetimes(x) = datenum(ldm);
+        saveTimes(x) = datenum(ldm);
     end
 end
 
-LiquidCal(1).LastDateModified = max(savetimes);
+LiquidCal_struct(1).LastDateModified = max(saveTimes);
 
 
 end

--- a/Functions/+BpodLib/+calibration/+liquid/+compatibility/createDummyData.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+compatibility/createDummyData.m
@@ -1,34 +1,58 @@
-function DummyValveManager = createDummyData()
+function DummyLiquidCal = createDummyData()
+% Create default/dummy LiquidCal object
 % DummyValveManager = createDummyData()
-% Create dummy default data for the liquid calibration
-% :return: the ValveDataManager object with the dummy data
-% :rtype: BpodLib.calibration.liquid.ValveDataManagerClass
-
+%
 % This function recreates the data originally shipped with Bpod_Gen2
+%
+% Returns
+% -------
+% DummyValveManager : BpodLib.calibration.liquid.ValveDataManagerClass
+%     LiquidCal with dummy data
 
-DummyValveManager = BpodLib.calibration.liquid.ValveDataManagerClass();
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
+DummyLiquidCal = BpodLib.calibration.liquid.ValveDataManagerClass();
 
 % Create valvenames 'Valve1' to 'Valve8'
 for i = 1:8
     valveName = sprintf('Valve%d', i);
-    DummyValveManager.createValve(valveName);
+    DummyLiquidCal.createValve(valveName);
 end
 
 % Add some dummy measurements
-valve1 = DummyValveManager.getValve('Valve1');
+valve1 = DummyLiquidCal.getValve('Valve1');
 valve1.addMeasurement(22, 2);
 valve1.addMeasurement(66, 9.5);
 valve1.addMeasurement(44, 5);
 valve1.addMeasurement(57, 7.5);
 valve1.addMeasurement(34, 3.5);
 
-valve3 = DummyValveManager.getValve('Valve3');
+valve3 = DummyLiquidCal.getValve('Valve3');
 valve3.addMeasurement(22, 1.5);
 valve3.addMeasurement(46, 5.5);
 valve3.addMeasurement(59, 7.5);
 valve3.addMeasurement(35, 3.5);
 valve3.addMeasurement(66, 8.5);
 
+% todo: these dates are different to the .JSON in Examples/
 % Update LastDateModified to reflect the dummy data
 valve1.LastDateModified = '2016-11-17 16:08:26';  % original from Bpod_Gen2
 % valve3.LastDateModified = char(datetime('2024-07-17 09:22:28'));  % the date of this function's creation

--- a/Functions/+BpodLib/+calibration/+liquid/+io/checkDefaultData.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+io/checkDefaultData.m
@@ -1,7 +1,17 @@
 function isDefault = checkDefaultData(LiquidCal)
-% isDefault = checkDefaultData(LiquidCal)
 % Check if the data is unchanged from the placeholder data shipped with Bpod
-% Returns char 'true' (is default), 'false' (user modified), or 'unknown'
+% isDefault = checkDefaultData(LiquidCal)
+%
+% This tests against the data in Bpod_Gen2/Examples/Examples Calibration Files/LiquidCalibration.json
+% 
+% Arguments
+% ---------
+% LiquidCal : BpodLib.calibration.liquid.ValveDataManagerClass or struct
+%
+% Returns
+% -------
+% isDefault : char
+%      'true' (is default), 'false' (user modified), or 'unknown'
 
 % Dummy data was created in 2016-11-17
 

--- a/Functions/+BpodLib/+calibration/+liquid/+io/checkDefaultData.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+io/checkDefaultData.m
@@ -1,9 +1,10 @@
 function isDefault = checkDefaultData(LiquidCal)
 % isDefault = checkDefaultData(LiquidCal)
 % Check if the data is unchanged from the placeholder data shipped with Bpod
-% Returns char 'true', 'false', or 'unknown'
-% todo: do better checks on this
-dummyManager = BpodLib.calibration.liquid.compatibility.createDummyData();
+% Returns char 'true' (is default), 'false' (user modified), or 'unknown'
+
+% Dummy data was created in 2016-11-17
+
 isDefault = 'true';
 if isa(LiquidCal, 'struct')
     if LiquidCal(1).LastDateModified > 736651.67253095
@@ -18,5 +19,4 @@ elseif isempty(LiquidCal)
 else
     warning('Could not determine if LiquidCal data has been user modified or not.')
 end
-
 end

--- a/Functions/+BpodLib/+calibration/+liquid/+io/load.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+io/load.m
@@ -1,10 +1,41 @@
-function liquidData = load(varargin)
+function LiquidCal = load(varargin)
 % Load a calibration file from disk
+% liquidData = load(_)
 %
-% :param type: Source to read for the file either 'statemachine' (default) or 'portarray'
-% :type type: char
-% :return liquidData: The liquid data determined to be for the state machine
-% :rtype: struct or BpodLib.calibration.liquid.ValveDataManagerClass
+% Keyword Arguments
+% -----------------
+% BpodSystem : BpodObject
+%     Whether to display messages in Command Window.
+% LocalDir : char
+%     LocalDir to use instead of BpodSystem.Path.LocalDir.
+%     Must be specified if BpodSystem is not.
+% type : char
+%     Source to read for the file either 'statemachine' (default) or 'portarray'
+%
+% Returns
+% -------
+% liquidData : struct or BpodLib.calibration.liquid.ValveDataManagerClass
+%     The liquid data determined to be for the state machine
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 p = inputParser();
 p.addParameter('BpodSystem', [])
@@ -43,13 +74,13 @@ if isJSON
 else
     assert(isLegacy, 'Expected legacy .mat file because no .json file was found')
     assert(strcmp(p.Results.type, 'statemachine'), 'BpodLib:LiquidCalibration:PortArrayJSONFail', 'Port Array not supported with old .mat format.')
-    liquidData = load(legacyPath, 'LiquidCal').LiquidCal;
+    LiquidCal = load(legacyPath, 'LiquidCal').LiquidCal;
     % Eventually this should return a warning for being unsupported
     return
 end
 
 assert(isfile(expectedFilepath), 'BpodLib:LiquidCalibrationLoad:FileNotFound', 'Liquid calibration file not found at %s', expectedFilepath)
 
-liquidData = BpodLib.calibration.liquid.ValveDataManagerClass('filepath', expectedFilepath);
+LiquidCal = BpodLib.calibration.liquid.ValveDataManagerClass('filepath', expectedFilepath);
 
 end

--- a/Functions/+BpodLib/+calibration/+liquid/+io/report.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+io/report.m
@@ -1,5 +1,30 @@
 function report(LiquidCal)
 % Print report of status of liquid calibration into Command Window
+% report(LiquidCal)
+%
+% Arguments
+% ---------
+% LiquidCal : BpodLib.calibration.liquid.ValveDataManagerClass or struct
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 % Issue warning if user hasn't calibrated anything
 if strcmp(BpodLib.calibration.liquid.io.checkDefaultData(LiquidCal), 'true')

--- a/Functions/+BpodLib/+calibration/+liquid/+io/save.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+io/save.m
@@ -1,7 +1,42 @@
-function save(ValveDataManagerStruct, varargin)
+function save(saveData, varargin)
 % Save liquid calibration data to disk
-% :param ValveDataManagerStruct: The output of ValveDataManager.createSaveData()
-% :type ValveDataManagerStruct: struct
+% save(saveData, _)
+%
+% Arguments
+% ---------
+% saveData : struct
+%     The output of ValveDataManager.createSaveData().
+%
+% Keyword Arguments
+% -----------------
+% BpodSystem : BpodObject
+%     BpodSystem used to identify the COM
+% type : char
+%     What kind of liquid calibration data it is. 'statemachine' or 'portarray'
+% filepath : char
+%     Filepath to save to. Must be specified if 'type' is not.
+% verbose : logical (default=true)
+%     Whether to display messages in Command Window.
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 p = inputParser();
 p.addParameter('BpodSystem', [])
@@ -11,10 +46,11 @@ p.addParameter('verbose', false)
 p.parse(varargin{:})
 BpodSystem = p.Results.BpodSystem;
 
-% We want data to be a struct from the get-go because we might want to insert additional data later on...
-assert(isa(ValveDataManagerStruct, 'struct'),'BpodLib:LiquidCalibrationSave:WrongFormat',...
+% LiquidCal should be converted into a a struct with .createSaveData()
+% first, as this allows arbitrary metadata to be saved prior to this final
+% process.
+assert(isa(saveData, 'struct'),'BpodLib:LiquidCalibrationSave:WrongFormat',...
     'Save data should be a structure.')
-savedata = ValveDataManagerStruct;
 
 % Determine the save location of the calibration file
 if isempty(p.Results.filepath)
@@ -36,8 +72,8 @@ end
 
 % Insert COM port metadata
 if ~isempty(BpodSystem)
-    if isfield(savedata.metadata, 'COM')
-        savedCOM = savedata.metadata.COM;
+    if isfield(saveData.metadata, 'COM')
+        savedCOM = saveData.metadata.COM;
     else
         savedCOM = 'none';
     end
@@ -48,12 +84,12 @@ if ~isempty(BpodSystem)
         warning('COM port has changed.')
         fprintf('Previous COM: %s\nNew COM: %s\n', savedCOM, currentCOM)
     end
-    savedata.metadata.COM = currentCOM;
+    saveData.metadata.COM = currentCOM;
 end
 
 
 % Write to JSON file
-writedata = jsonencode(savedata, 'PrettyPrint', true);
+writedata = jsonencode(saveData, 'PrettyPrint', true);
 fid = fopen(filepath, 'w');
 fwrite(fid, writedata, 'char');
 fclose(fid);

--- a/Functions/+BpodLib/+calibration/+liquid/+portarray/createValveManager.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+portarray/createValveManager.m
@@ -1,12 +1,42 @@
-function ValveManager = createValveManager(BpodSystem)
-% Create an empty ValveDataManager for PortArrays
+function PortArrayCal = createValveManager(BpodSystem)
+% Create an empty Port Array Module liquid calibration manager
+% PortArrayCal = createValveManager(BpodSystem)
+%
+% Arguments
+% ---------
+% BpodSystem : BpodObject
+%
+% Returns
+% -------
+% PortArrayCal : BpodLib.calibration.liquid.ValveDataManagerClass
+%     Manager pre-filled with empty eligible port array valves.
 
-ValveManager = BpodLib.calibration.liquid.ValveDataManagerClass();
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
+PortArrayCal = BpodLib.calibration.liquid.ValveDataManagerClass();
 nModuleChannels = numel(BpodSystem.Modules.Connected);
 
-for portarraynumber = 1:nModuleChannels
+for moduleNumber = 1:nModuleChannels
     for valveIndex = 1:4
-        ValveManager.createValve(sprintf('PA%i_%i', portarraynumber, valveIndex));
+        PortArrayCal.createValve(sprintf('PA%i_%i', moduleNumber, valveIndex));
     end
 end
 

--- a/Functions/+BpodLib/+calibration/+liquid/+portarray/initialise.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+portarray/initialise.m
@@ -1,8 +1,51 @@
 function initialise(BpodSystem)
+% Initialise a new port array calibration configuration
+% initialise(BpodSystem)
+%
+% Arguments
+% ---------
+% BpodSystem : BpodObject
+
+% docstring
+% signature
+%
+% Arguments
+% ---------
+% myarg : int
+%     Descriptor
+%
+% Keyword Arguments
+% -----------------
+% verbose : logical (default=true)
+%     Whether to display messages in Command Window.
+%
+% Returns
+% -------
+% completed : int
+%     Returns 1 if successful, 0 otherwise
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 if isempty(BpodSystem.CalibrationTables.PortArrays)
     BpodSystem.CalibrationTables.PortArrays = BpodLib.calibration.liquid.portarray.createValveManager(BpodSystem);
 else
     error('BpodLib:PortArrayInitialise:ExistingData', 'PortArray data is already loaded in, maybe you want BpodLib.calibration.liquid.portarray.launchCalibrator(BpodSystem)')
 end
-

--- a/Functions/+BpodLib/+calibration/+liquid/+portarray/initialise.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+portarray/initialise.m
@@ -6,4 +6,3 @@ else
     error('BpodLib:PortArrayInitialise:ExistingData', 'PortArray data is already loaded in, maybe you want BpodLib.calibration.liquid.portarray.launchCalibrator(BpodSystem)')
 end
 
-BpodLib.calibration.liquid.portarray.launchCalibrator(BpodSystem)

--- a/Functions/+BpodLib/+calibration/+liquid/+portarray/launchCalibrator.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+portarray/launchCalibrator.m
@@ -1,8 +1,34 @@
 function launchCalibrator(BpodSystem)
-% Launch a liquid calibrator with the port array
+% Launch the liquid calibrator UI for port array data
+% launchCalibrator(BpodSystem)
+%
+% Arguments
+% ---------
+% BpodSystem : BpodObject
 
-savepath = fullfile(BpodLib.path.getPath('liquidcalibration', BpodSystem), 'LiquidCalibration-PortArrays.json');
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
+savePath = fullfile(BpodLib.path.getPath('liquidcalibration', BpodSystem), 'LiquidCalibration-PortArrays.json');
 if isempty(BpodSystem.CalibrationTables.PortArrays)
     error('BpodLib:portarraylaunchCalibrator:NoData', "No existing port array data found, did you mean BpodLib.calibration.liquid.portarray.initialize(BpodSystem) ?")
 end
-BpodLib.calibration.liquid.LiquidCalibratorUI(BpodSystem.CalibrationTables.PortArrays, 'BpodSystem', BpodSystem, 'savepath', savepath);
+
+BpodLib.calibration.liquid.LiquidCalibratorUI(BpodSystem.CalibrationTables.PortArrays, 'BpodSystem', BpodSystem, 'savepath', savePath);

--- a/Functions/+BpodLib/+calibration/+liquid/+ui/SuggestPointsGUI.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+ui/SuggestPointsGUI.m
@@ -62,12 +62,7 @@ classdef SuggestPointsGUI < handle
         end
         
         function result = focus(obj)
-            result = false;
-            if ~isvalid(obj.GUIHandles.Figure)
-                return
-            end
-            figure(obj.GUIHandles.Figure);
-            result = true;
+            result = BpodLib.ui.raise(obj);
         end
 
         function close(obj)

--- a/Functions/+BpodLib/+calibration/+liquid/+ui/SuggestPointsGUI.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+ui/SuggestPointsGUI.m
@@ -1,7 +1,27 @@
+% Window for users to select valves to create duration suggestions for
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
 classdef SuggestPointsGUI < handle
-    %SUGGESTPOINTSGUI Summary of this class goes here
-    %   Detailed explanation goes here
-    
+       
     properties
         GUIHandles
         valveNames
@@ -9,11 +29,10 @@ classdef SuggestPointsGUI < handle
     end
     
     methods
-        function obj = SuggestPointsGUI(ValveManager, okcallback)
-            %SUGGESTPOINTSGUI 
-            %   Detailed explanation goes here
+        function obj = SuggestPointsGUI(LiquidCal, okcallback)
+            % obj = SuggestPointsGUI(LiquidCal, okcallback)
 
-            valveNames = ValveManager.getValveNames();
+            valveNames = LiquidCal.getValveNames();
             obj.valveNames = valveNames;
 
             obj.GUIHandles = struct();

--- a/Functions/+BpodLib/+calibration/+liquid/+ui/TestSpecificAmountGUI.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+ui/TestSpecificAmountGUI.m
@@ -1,3 +1,25 @@
+% Window for users to test whether their liquid calibration is accurate.
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
 classdef TestSpecificAmountGUI < handle
 properties
     BpodSystem
@@ -11,8 +33,7 @@ end
 
 methods
     function obj = TestSpecificAmountGUI(BpodSystem, LiquidCal)
-        %TestSpecificAmountGUI(BpodSystem, LiquidCal)
-        % GUI for testing specific amounts of liquid
+        % obj = TestSpecificAmountGUI(BpodSystem, LiquidCal)
 
         obj.BpodSystem = BpodSystem;
         obj.LiquidCal = LiquidCal;

--- a/Functions/+BpodLib/+calibration/+liquid/+ui/TestSpecificAmountGUI.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+ui/TestSpecificAmountGUI.m
@@ -218,10 +218,7 @@ methods
     end
 
     function result = focus(obj)
-        result = false;
-        % todo: fix this pattern
-        figure(obj.GUIHandles.Figure)
-        result = true;
+        result = BpodLib.ui.raise(obj);
     end
 end
 end

--- a/Functions/+BpodLib/+calibration/+liquid/+utils/checkCOM.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+utils/checkCOM.m
@@ -1,6 +1,26 @@
 function matchingCOM = checkCOM(BpodSystem)
-%matchingCOM = checkCOM(BpodSystem)
 % Check if the COM port in the calibration file matches the current BpodSystem COM port.
+% matchingCOM = checkCOM(BpodSystem)
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 matchingCOM = 'unknown';
 BpodSystemCOM = BpodLib.utils.getCurrentCOM(BpodSystem);

--- a/Functions/+BpodLib/+calibration/+liquid/+utils/suggestDuration.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+utils/suggestDuration.m
@@ -1,6 +1,41 @@
 function suggestedDuration_ms = suggestDuration(valveobject, rangeLow, rangeHigh)
-%duration = suggestDuration(valve)
 % Suggest a duration for the valve based on its type and size.
+% duration = suggestDuration(valve)
+%
+% Arguments
+% ---------
+% valveobject : BpodLib.calibration.liquid.ValveDataClass
+%     A single valve's object
+% rangeLow : double
+%     The minimum amount expected to be dispensed
+% rangeHigh : double
+%     The maximum amount expected to be dispensed
+%
+%
+% Returns
+% -------
+% suggestDuration_ms : double
+%     Duration that fills the gap in the existing calibration data
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 if ~isempty(valveobject.Durations)
     durations = valveobject.Durations';

--- a/Functions/+BpodLib/+calibration/+liquid/LiquidCalibratorUI.m
+++ b/Functions/+BpodLib/+calibration/+liquid/LiquidCalibratorUI.m
@@ -158,7 +158,7 @@ methods
         end
 
         % Add pending measurements to list
-        PendingDurations = obj.PendingMeasurements.data.(ValveToShowName);
+        PendingDurations = obj.PendingMeasurements.getValvePending(ValveToShowName);
         if ~isempty(PendingDurations)
             nPendingMeasurements = length(PendingDurations);
             for x = 1:nPendingMeasurements
@@ -195,7 +195,7 @@ methods
             set(AxCalib, 'tickdir', 'out', 'box', 'off');
             Ymax = max(ValveData.Amounts)+.1*max(ValveData.Amounts);
             % Add pending measurement datapoints
-            PendingDurations = obj.PendingMeasurements.data.(ValveToShowName);
+            PendingDurations = obj.PendingMeasurements.getValvePending(ValveToShowName);
             if ~isempty(PendingDurations)
                 nPendingMeasurements = length(PendingDurations);
                 for y = 1:nPendingMeasurements
@@ -328,7 +328,7 @@ methods
         Completed = BpodLib.calibration.liquid.RunRewardCalibration(obj.BpodSystem, str2double(get(obj.GUIHandles.nPulsesEdit, 'string')), valveNames, pulseDurations_ms / 1000, 'PulseInterval', .2);
         if Completed
             % -- Create GUI for entering measurements
-            allValveNames = fields(obj.PendingMeasurements.data);
+            allValveNames = obj.PendingMeasurements.getValveNames();
             EntryGUI = BpodLib.calibration.liquid.ui.ValueEntryGUI(allValveNames, @obj.AddCalMeasurements);
             EntryGUI.setPending(valveNames)
             obj.GUIHandles.ValueEntryGUI = EntryGUI;

--- a/Functions/+BpodLib/+calibration/+liquid/LiquidCalibratorUI.m
+++ b/Functions/+BpodLib/+calibration/+liquid/LiquidCalibratorUI.m
@@ -1,17 +1,34 @@
 % UI for liquid calibration
+%
+% GUIHandles
+% ----------
+% - MainFig: figure
+% - ValveSelector: listbox
+% - MeasurementSelector: listbox
+% - AddMeasurementButton: pushbutton
+% - RemoveMeasurementButton: pushbutton
+% - CalibrationCurveAxes: axes
+% - nPulsesEdit: edit
+% - SuggestPointsButton: pushbutton
 
 %{
-GUIHandles
-----------
-- MainFig: figure
-- ValveSelector: listbox
-- MeasurementSelector: listbox
-- AddMeasurementButton: pushbutton
-- RemoveMeasurementButton: pushbutton
-- CalibrationCurveAxes: axes
-- nPulsesEdit: edit
-- SuggestPointsButton: pushbutton
+----------------------------------------------------------------------------
 
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %}
 
 classdef LiquidCalibratorUI < handle

--- a/Functions/+BpodLib/+calibration/+liquid/PendingMeasurementManager.m
+++ b/Functions/+BpodLib/+calibration/+liquid/PendingMeasurementManager.m
@@ -1,58 +1,89 @@
+% Manager for pending data
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
 classdef PendingMeasurementManager < handle
 properties
-    ValveManager
-    data
+    LiquidCal
+    Pending
 end
 
 methods
-    function obj = PendingMeasurementManager(ValveManager)
-        obj.ValveManager = ValveManager;
+    function obj = PendingMeasurementManager(LiquidCal)
+        % obj = PendingMeasurementManager(LiquidCal)
+        obj.LiquidCal = LiquidCal;
 
-        % Initialize the data structure with empty arrays for each valve
-        valveNames = ValveManager.getValveNames();
-        obj.data = struct();
+        % Initialize the Pending structure with empty arrays for each valve
+        valveNames = LiquidCal.getValveNames();
+        obj.Pending = struct();
         for idx = 1:numel(valveNames)
             valvename = valveNames{idx};
-            obj.data.(valvename) = [];
+            obj.Pending.(valvename) = [];
         end
     end
 
     function addPending(obj, valvename, duration_ms)
         % Add a pending measurement for a valve
-        assert(ismember(valvename, fieldnames(obj.data)), 'Unknown valve requested')
-        assert(~ismember(duration_ms, obj.data.(valvename)), 'BpodLib:LiquidCalibration:ExistingDuration', 'Duration already exists in pending')
-        assert(~ismember(duration_ms, obj.ValveManager.getValve(valvename).Durations), 'BpodLib:LiquidCalibration:ExistingDuration', 'Duration already exists in completed data')
-        obj.data.(valvename) = [obj.data.(valvename), duration_ms];
+        assert(ismember(valvename, fieldnames(obj.Pending)), 'Unknown valve requested')
+        assert(~ismember(duration_ms, obj.Pending.(valvename)), 'BpodLib:LiquidCalibration:ExistingDuration', 'Duration already exists in pending')
+        assert(~ismember(duration_ms, obj.LiquidCal.getValve(valvename).Durations), 'BpodLib:LiquidCalibration:ExistingDuration', 'Duration already exists in completed data')
+        obj.Pending.(valvename) = [obj.Pending.(valvename), duration_ms];
     end
 
     function removePending(obj, valvename, duration_ms)
-        assert(ismember(valvename, fieldnames(obj.data)), 'Unknown valve requested')
-        assert(ismember(duration_ms, obj.data.(valvename)), 'Duration for valve should exist')
-        obj.data.(valvename) = setdiff(obj.data.(valvename), duration_ms);
+        assert(ismember(valvename, fieldnames(obj.Pending)), 'Unknown valve requested')
+        assert(ismember(duration_ms, obj.Pending.(valvename)), 'Duration for valve should exist')
+        obj.Pending.(valvename) = setdiff(obj.Pending.(valvename), duration_ms);
     end
 
     function completeMeasurement(obj, valvename, duration_ms, amount)
         % Complete a measurement for a valve
-        assert(ismember(valvename, fieldnames(obj.data)), 'Unknown valve requested')
-        assert(ismember(duration_ms, obj.data.(valvename)), 'Duration for completed measurement should have been pending')
+        assert(ismember(valvename, fieldnames(obj.Pending)), 'Unknown valve requested')
+        assert(ismember(duration_ms, obj.Pending.(valvename)), 'Duration for completed measurement should have been pending')
 
         % Remove the completed measurement from pending
-        obj.data.(valvename) = setdiff(obj.data.(valvename), duration_ms);
+        obj.Pending.(valvename) = setdiff(obj.Pending.(valvename), duration_ms);
 
         % Add the completed measurement to the completed list
-        obj.ValveManager.getValve(valvename).addMeasurement(duration_ms, amount);
+        obj.LiquidCal.getValve(valvename).addMeasurement(duration_ms, amount);
+    end
+
+    function Durations_ms = getValvePending(obj, valveName)
+        Durations_ms = obj.Pending.(valveName);
+    end
+
+    function valveNames = getValveNames(obj)
+        valveNames = fields(obj.Pending);
     end
 
     function [valveNames, Durations_ms] = getPending(obj)
         % Get the pending measurements for all valves
-        % Used to generate GUI data and to create calibration runscript
+        % Used to generate GUI Pending and to create calibration runscript
         valveNames = {};
         Durations_ms = [];
 
-        allValveNames = fieldnames(obj.data);
+        allValveNames = fieldnames(obj.Pending);
         for idx = 1:numel(allValveNames)
             valvename = allValveNames{idx};
-            pending_durations = obj.data.(valvename);
+            pending_durations = obj.Pending.(valvename);
             if ~isempty(pending_durations)
                 first_duration_s = pending_durations(1);
                 valveNames{end+1} = valvename;

--- a/Functions/+BpodLib/+calibration/+liquid/RunRewardCalibration.m
+++ b/Functions/+BpodLib/+calibration/+liquid/RunRewardCalibration.m
@@ -36,7 +36,7 @@ end
 
 % Build valve testing information
 if p.Results.verbose
-    fprintf('Liquid Calibration with .\n')
+    fprintf('Running reward calibration pulses with:\n')
 end
 data = struct('name', [], 'outputaction', [], 'type', []);
 ValvePhysicalAddress = 2.^(0:7);
@@ -44,7 +44,7 @@ nValves = length(TargetValves);
 for idx = 1:nValves
     valveName = TargetValves{idx};
     if p.Results.verbose
-        fprintf('\t%s for %.1f ms\n', valveName, PulseDurations(idx) / 1000)
+        fprintf('\t%s for %.1f ms\n', valveName, PulseDurations(idx) * 1000)
     end
     if strcmp(valveName(1:5), 'Valve')
         data(idx).name = valveName;
@@ -61,9 +61,6 @@ for idx = 1:nValves
     end
 end
 
-if p.Results.verbose
-    fprintf('%s start\n', valveName, PulseDurations(idx) / 1000)
-end
 
 % Create the set of pulses to be tested out
 sma = NewStateMatrix();

--- a/Functions/+BpodLib/+calibration/+liquid/RunRewardCalibration.m
+++ b/Functions/+BpodLib/+calibration/+liquid/RunRewardCalibration.m
@@ -1,20 +1,53 @@
-function Completed = RunRewardCalibration(BpodSystem, nPulses, TargetValves, PulseDurations, varargin)
-% Make the specified valves pulse for the specified durations
-% :param BpodSystem: the Bpod system object
-% :type BpodSystem: struct
-% :param nPulses: the number of pulses to deliver
-% :type nPulses: int
-% :param TargetValves: the valves to pulse, format as 'Valve1' (state machine's port) or 'PA1-2' (for port array module)
-% :type TargetValves: cell array of char
-% :param PulseDurations: the duration of each pulse (s)
-% :type PulseDurations: array of double
-% :param PulseInterval: the interval between pulses of each valve (s), optional
-% :type PulseInterval: double
-% :param PulseSetPause: the pause between each set of pulses (s), optional
-% :type PulseSetPause: double
-% :return: whether the calibration was completed
-% :rtype: int
+function completed = RunRewardCalibration(BpodSystem, nPulses, TargetValves, PulseDurations, varargin)
+% Run a series of reward calibration pulses for specified valves.
+% completed = RunRewardCalibration(BpodSystem, nPulses, Targetvalves, PulseDurations, _)
+%
+% Parameters
+% ----------
+% BpodSystem : struct
+%     The Bpod system object
+% nPulses : int
+%     Number of pulse repetitions to deliver
+% TargetValves : cell array of char
+%     Valves to pulse ('Valve1' for state machine port, 'PA1-2' for port array)
+% PulseDurations : array of double
+%     Duration of each pulse in seconds
+%
+% Keyword Arguments
+% -----------------
+% PulseInterval : double (default=0.2)
+%     Interval between pulses of each valve (seconds)
+% PulseSetPause : double (default=0.5)
+%     Pause between each set of pulses (seconds)
+% verbose : logical (default=true)
+%     Whether to display progress messages
+%
+% Returns
+% -------
+% completed : int
+%     1 if calibration completed successfully, 0 otherwise
 
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
+completed = 0;
 
 p = inputParser();
 p.addParameter('PulseInterval', 0.2, @isnumeric);
@@ -22,22 +55,19 @@ p.addParameter('PulseSetPause', 0.5, @isnumeric);
 p.addParameter('verbose', true)
 p.parse(varargin{:})
 
-Completed = 0;
 PulseInterval = p.Results.PulseInterval;
-PulseDurations(PulseDurations == 0) = NaN;
-% if sum(PulseDurations > 1) > 0
-    % error('Pulse durations should be specified in seconds.')
-% end
+
 for x = 1:length(PulseDurations)
     if isnan(PulseDurations(x))
         PulseDurations(x) = 0;
     end
 end
 
-% Build valve testing information
+%% Build valve testing information
 if p.Results.verbose
     fprintf('Running reward calibration pulses with:\n')
 end
+
 data = struct('name', [], 'outputaction', [], 'type', []);
 ValvePhysicalAddress = 2.^(0:7);
 nValves = length(TargetValves);
@@ -46,12 +76,12 @@ for idx = 1:nValves
     if p.Results.verbose
         fprintf('\t%s for %.1f ms\n', valveName, PulseDurations(idx) * 1000)
     end
-    if strcmp(valveName(1:5), 'Valve')
+    if strncmp(valveName, 'Valve', 5)
         data(idx).name = valveName;
         valveID = str2double(valveName(6));
         data(idx).outputaction = {'ValveState', ValvePhysicalAddress(valveID)};
         data(idx).type = 'wire';
-    elseif strcmp(valveName(1:2), 'PA')
+    elseif strncmp(valveName, 'PA', 2)
         data(idx).name = valveName;
         portnumber = str2double(valveName(5)) - 1;  % PortArray is 0-indexed
         data(idx).outputaction = {valveName(1:3), ['V', portnumber]};
@@ -61,64 +91,69 @@ for idx = 1:nValves
     end
 end
 
-
-% Create the set of pulses to be tested out
+%% Create pulse delivery state matrix
 sma = NewStateMatrix();
 for y = 1:nValves
-    valvedata = data(y);
-    if strcmp(valvedata.type, 'wire')
+    valveData = data(y);
+    
+    if strcmp(valveData.type, 'wire')
         % Valve is open only while the state is active
-        openvalveaction = valvedata.outputaction;
-        nextstate_pulseend = ['Delay' valvedata.name];
+        openValveAction = valveData.outputaction;
+        nextStatePulseEnd = ['Delay' valveData.name];
     else
-        % Valve is switched open and must have another message sent to close
-        openvalveaction = valvedata.outputaction;
-        openvalveaction{2} = [openvalveaction{2} 1];
-        nextstate_pulseend = ['PulseClosed' valvedata.name]; % use additional state to send close message
-        closevalveaction = valvedata.outputaction;
-        closevalveaction{2} = [closevalveaction{2} 0];
+        % Port arrays must be explicitly closed
+        % output actions are ['V' portnumber state]
+        openValveAction = valveData.outputaction;
+        openValveAction{2} = [openValveAction{2} 1];
+        nextStatePulseEnd = ['PulseClosed', valveData.name]; % use additional state to send close message
+
+        closeValveAction = valveData.outputaction;
+        closeValveAction{2} = [closeValveAction{2} 0];
     end
 
-    sma = AddState(sma, 'Name', ['Pulse' valvedata.name], ...
+    sma = AddState(sma, 'Name', ['Pulse' valveData.name], ...
                         'Timer', PulseDurations(y),...
                         'StateChangeConditions', ...
-                        {'Tup', nextstate_pulseend},...
-                        'OutputActions', openvalveaction);
+                        {'Tup', nextStatePulseEnd},...
+                        'OutputActions', openValveAction);
 
-    if strcmp(valvedata.type, 'serial')
-        sma = AddState(sma, 'Name', ['PulseClose' valvedata.name], ...
+    if strcmp(valveData.type, 'serial')
+        sma = AddState(sma, 'Name', ['PulseClose' valveData.name], ...
                             'Timer', 0,...
                             'StateChangeConditions', ...
-                            {'Tup', ['Delay' valvedata.name]},...
-                            'OutputActions', closevalveaction);
+                            {'Tup', ['Delay' valveData.name]},...
+                            'OutputActions', closeValveAction);
     end
 
     if y < nValves
-        sma = AddState(sma, 'Name', ['Delay' valvedata.name], ...
+        sma = AddState(sma, 'Name', ['Delay' valveData.name], ...
                             'Timer', PulseInterval,...
                             'StateChangeConditions', ...
                             {'Tup', ['Pulse' data(y+1).name]},...
                             'OutputActions', {});
     else
-        sma = AddState(sma, 'Name', ['Delay' valvedata.name], ...
+        sma = AddState(sma, 'Name', ['Delay' valveData.name], ...
                             'Timer', PulseInterval,...
                             'StateChangeConditions', ...
                             {'Tup', 'exit'},...
                             'OutputActions', {});
     end
 end
+
+%% Execute pulses
 SendStateMatrix(sma);
 
-% Do the pulses
-progressbar;
 for x = 1:nPulses
     progressbar(x/nPulses)
+
     if BpodSystem.EmulatorMode == 0
         RunStateMatrix;
         pause(p.Results.PulseSetPause);
     else
-        disp('Emulator mode detected, reward calibration will not run but values can be entered.');
-        Completed = 1;
+        if x == 1 && p.Results.verbose
+            disp('Emulator mode detected, reward calibration will not run but values can be entered.');
+        end
+        completed = 1;
         progressbar(1)
     end
     if BpodSystem.Status.BeingUsed == 0
@@ -126,6 +161,6 @@ for x = 1:nPulses
         return
     end
 end
-Completed = 1;
+completed = 1;
 BpodSystem.Status.BeingUsed = 0;
 end

--- a/Functions/+BpodLib/+calibration/+liquid/ValveDataClass.m
+++ b/Functions/+BpodLib/+calibration/+liquid/ValveDataClass.m
@@ -1,7 +1,46 @@
-% Class definition for ValveDataClass
-% This class is used to store data for a single valve, including the valve name, the durations and amounts of liquid dispensed, the coefficients of the polynomial fit to the data, and the date the data was last modified.
-% Note that this is a handle class, so the object is passed by reference and modifications to the object will be reflected in all references to the object.
+% ValveDataClass - Handle class for storing and managing valve calibration data.
+%
+% This class stores calibration data for a single valve, including:
+% - Valve name and last modification date
+% - Measured durations and liquid amounts
+% - Polynomial coefficients for the calibration curve
+%
+% Properties:
+%   ValveName - Name of the valve (char)
+%   LastDateModified - ISO 8601 timestamp of last modification (char)
+%   Coeffs - Polynomial coefficients for calibration curve (double array)
+%   Durations - Valve opening durations in ms (double array)
+%   Amounts - Liquid amounts dispensed in uL (double array)
+%
+% Methods:
+%   ValveDataClass - Constructor
+%   load - Load data from struct
+%   addMeasurement - Add new measurement point
+%   removeMeasurement - Remove measurement point
+%   updateCoeffs - Update polynomial coefficients
+%   getValveTime - Calculate valve time for desired amount
+%   struct - Convert object to struct
+%   plot - Plot calibration data and curve
 
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 classdef ValveDataClass < handle
 properties
@@ -26,9 +65,12 @@ methods
     end
 
     function load(obj, rawstruct)
-        % Load data from the saved struct
-        % :param rawstruct: struct with fields ValveName, LastDateModified, Coeffs, Durations, Amounts
-        % :type rawstruct: struct
+        % Load data from saved struct into object
+        % obj.load(rawstruct)
+        %
+        % Inputs:
+        %   rawStruct - Struct containing valve data with fields:
+        %       ValveName, LastDateModified, Coeffs, Durations, Amounts
         obj.ValveName = rawstruct.ValveName;
         obj.LastDateModified = rawstruct.LastDateModified;
         obj.Coeffs = rawstruct.Coeffs;
@@ -37,12 +79,14 @@ methods
     end
 
     function addMeasurement(obj, duration, amount)
-        %addMeasurement(duration, amount)
         % Add a new measurement to the data set
-        % :param duration: the duration of the valve opening (ms)
-        % :type duration: double
-        % :param amount: the amount of liquid dispensed (uL)
-        % :type amount: double
+        % addMeasurement(duration, amount)
+        % Arguments
+        % ---------
+        % duration : double
+        %     Valve opening duration in milliseconds
+        % amount : double
+        %     Liquid amount dispensed in microliters
 
         if isnan(amount) || amount < 0
             error('BpodLib:ValveDataClass:InvalidAmount', 'Amount must be a positive number')
@@ -56,11 +100,17 @@ methods
     end
 
     function removeMeasurement(obj, value, varargin)
-        % Remove a measurement from the data set
-        % :param value: the index of the measurement to remove, can be duration 
-        % :type value: double
-        % :param isduration: flag for duration instead of index
-        % :type isduration: bool
+        % Remove a measurement point.
+        %
+        % Parameters
+        % ----------
+        % value : double
+        %     Either index of measurement to remove or duration value
+        %
+        % Keyword Arguments
+        % -----------------
+        % duration : logical, optional
+        %     If true, value is treated as duration rather than index (default: false)
 
         p = inputParser();
         p.addParameter('duration', false)
@@ -96,12 +146,17 @@ methods
     end
 
     function valveTime_ms = getValveTime(obj, liquidAmount_uL)
-        %valveTime_ms = getValveTime(liquidAmount_uL)
-        % Get the valve open time for a given liquid amount
-        % :param liquidAmount_uL: the amount of liquid to dispense (uL)
-        % :type liquidAmount_uL: double
-        % :return: the time to open the valve (ms)
-        % :rtype: double
+        % Calculate valve time needed for target amount.
+        %
+        % Parameters
+        % ----------
+        % liquidAmount_uL : double
+        %     Desired liquid amount in microliters
+        %
+        % Returns
+        % -------
+        % valveTime_ms : double
+        %     Required valve open time in milliseconds
 
         % Note that time is in ms but state matrix defines time in seconds
         
@@ -119,9 +174,6 @@ methods
 
     function out = struct(obj)
         % Convert the object to a struct
-        % Ensures the object data is in save formatted struct
-        % :return: the object data as a struct
-        % :rtype: struct
         
         if numel(obj.Durations) ~= numel(obj.Amounts)
             error('BpodLib:ValveDataClass:DataMismatch', 'Durations and Amounts must have the same number of elements');
@@ -137,13 +189,23 @@ methods
     end
 
     function plot(obj, varargin)
-        % Plot the data
-        % :param ax: the axes to plot on (default: current axes)
-        % :type ax: handle
-        % :param color: the color of the plot (default: 'k')
-        % :type color: char
-        % :param legendname: the name for the legend (default: ValveName)
-        % :type legendname: char
+        % Visualize calibration data and curve.
+        %
+        % Keyword Arguments
+        % -----------------
+        % ax : handle, optional
+        %     Axes handle to plot on (default: current axes)
+        % color : char, optional
+        %     Plot color (default: 'k')
+        % linewidth : double, optional
+        %     Line width (default: 1.5)
+        % legendname : char, optional
+        %     Legend entry (default: ValveName)
+        %
+        % Raises
+        % ------
+        % BpodLib:ValveDataClass:InsufficientData
+        %     If fewer than 2 measurements exist
 
         p = inputParser();
         p.addParameter('ax', gca, @ishandle);

--- a/Functions/+BpodLib/+calibration/+liquid/ValveDataClass.m
+++ b/Functions/+BpodLib/+calibration/+liquid/ValveDataClass.m
@@ -68,9 +68,11 @@ methods
         % Load data from saved struct into object
         % obj.load(rawstruct)
         %
-        % Inputs:
-        %   rawStruct - Struct containing valve data with fields:
-        %       ValveName, LastDateModified, Coeffs, Durations, Amounts
+        % Arguments
+        % ---------
+        % rawStruct : struct
+        %     valve data with fields:
+        %     ValveName, LastDateModified, Coeffs, Durations, Amounts
         obj.ValveName = rawstruct.ValveName;
         obj.LastDateModified = rawstruct.LastDateModified;
         obj.Coeffs = rawstruct.Coeffs;
@@ -102,7 +104,7 @@ methods
     function removeMeasurement(obj, value, varargin)
         % Remove a measurement point.
         %
-        % Parameters
+        % Arguments
         % ----------
         % value : double
         %     Either index of measurement to remove or duration value
@@ -148,7 +150,7 @@ methods
     function valveTime_ms = getValveTime(obj, liquidAmount_uL)
         % Calculate valve time needed for target amount.
         %
-        % Parameters
+        % Arguments
         % ----------
         % liquidAmount_uL : double
         %     Desired liquid amount in microliters
@@ -201,11 +203,6 @@ methods
         %     Line width (default: 1.5)
         % legendname : char, optional
         %     Legend entry (default: ValveName)
-        %
-        % Raises
-        % ------
-        % BpodLib:ValveDataClass:InsufficientData
-        %     If fewer than 2 measurements exist
 
         p = inputParser();
         p.addParameter('ax', gca, @ishandle);

--- a/Functions/+BpodLib/+calibration/+liquid/ValveDataManagerClass.m
+++ b/Functions/+BpodLib/+calibration/+liquid/ValveDataManagerClass.m
@@ -37,7 +37,7 @@ methods
         % Keyword Arguments
         % -----------------
         % filepath : char
-        %     Path to file to auto load from
+        %     Path to file to auto load from, if empty initialises empty manager.
 
         p = inputParser();
         p.addParameter('filepath', '', @ischar);

--- a/Functions/+BpodLib/+calibration/+liquid/ValveDataManagerClass.m
+++ b/Functions/+BpodLib/+calibration/+liquid/ValveDataManagerClass.m
@@ -1,6 +1,27 @@
-% Class for managing ValveData objects
-% This class is used to store ValveData objects for multiple valves, and provides methods for getting and saving data.
-% The valve datas are stored in a cell array, with each cell containing a ValveData object (a handle) for a single valve.
+% ValveDataManagerClass - Handle class for storing and managing multiple valve calibration data
+%
+% This class can store multiple valve calibration data
+% This is the OOP version of the LiquidCal struct from <1.8.1
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 classdef ValveDataManagerClass < handle
 properties
@@ -10,10 +31,14 @@ end
 
 methods
     function obj = ValveDataManagerClass(varargin)
-        % Create the ValveDataManager
-        % :param filepath: the path to a file to load data from, optional
-        % :type filepath: char
-        
+        % Container class for managing multiple multiple valves
+        % obj = ValvedataManagerClass(_)
+        %
+        % Keyword Arguments
+        % -----------------
+        % filepath : char
+        %     Path to file to auto load from
+
         p = inputParser();
         p.addParameter('filepath', '', @ischar);
         p.parse(varargin{:});
@@ -29,11 +54,18 @@ methods
     end
 
     function valveData = getValve(obj, valveName)
-        % Get the ValveData object for a valve
-        % :param valveName: the name of the valve to get data for, or the valve number X ('ValveX')
-        % :type valveName: char or int
-        % :return valveData: the ValveData object for the valve (a handle)
-        % :rtype valveData: BpodLib.calibration.liquid.ValveDataClass
+        % Return valve object
+        % valveData = getValve(valveName)
+        %
+        % Arguments
+        % ---------
+        % valveName : char or double
+        %     Identity of vlve to retrieve
+        %
+        % Returns
+        % -------
+        % valveData : BpodLib.calibration.liquid.ValveDataClass
+        %     Single valve data object
 
         if isa(valveName, 'double')
             valveName = sprintf('Valve%d', valveName);
@@ -51,11 +83,19 @@ methods
     end
 
     function valveData = createValve(obj, valveName)
-        % Create a new ValveData object for a valve
-        % :param valveName: the name of the valve to create data for
-        % :type valveName: char or string
-        % :return valveData: the new ValveData object
-        % :rtype valveData: BpodLib.calibration.liquid.ValveDataClass
+        % Create a new valve within the manager
+        % valveData = createValve(valveName)
+        %
+        % Arguments
+        % ---------
+        % valveName : char
+        %     Name of the new valve
+        %
+        % Returns
+        % -------
+        % valveData : BpodLib.calibration.liquid.ValveDataClass
+        %     The new ValveData object
+
         valveData = BpodLib.calibration.liquid.ValveDataClass();
         valveData.ValveName = valveName;
         if isfield(obj.ValveDatas, valveName)
@@ -67,23 +107,31 @@ methods
 
     function valveNames = getValveNames(obj)
         % Get the names of all valves
-        % :return valveNames: the names of all valves
-        % :rtype valveNames: cell array of strings
+        % 
+        % Returns
+        % -------
+        % valveNames : cell array of strings
+        %     Names of all valves
 
         valveNames = fieldnames(obj.ValveDatas);
     end
 
     function n_Valves = nValves(obj)
         % Get number of valves stored in file
-        % :return n_Valves: number of valve
-        % :rtype n_Valves: int
+        % Returns
+        % -------
+        % n_Valves : double
+        %     Number of valves in the manager
 
         n_Valves = numel(obj.getValveNames);
     end
 
     function savedata = createSaveData(obj)
-        % Create a save-ready format of the manager
-        % :return savedata: Structure formatted for json encoding
+        % Create a file save-ready format of the manager
+        % Returns
+        % -------
+        % savedata : struct
+        %     Structure formatted for json encoding
 
         % -- Create save data struct
         % Initialize struct array (jsonencode will write as array of objects)
@@ -103,11 +151,13 @@ methods
 
     function saveData(obj, filepath)
         % Convenience function to save data, BpodLib.calibration.liquid.io.save is preferred
-        % :param filepath: the path to the file to save
-        % :type filepath: char
+        % 
+        % Arguments
+        % ---------
+        % filepath : char
+        %     The path to the file to save to
         %
-        % Save data JSON format
-        % ---------------------
+        % JSON save format
         % metadata: object
         %     modification_datetime: string
         % ValveDatas: array of objects
@@ -126,11 +176,18 @@ methods
     end
 
     function loadData(obj, filepath, varargin)
-        % Load data from a file
-        % :param filepath: the path to the file to load
-        % :type filepath: char
-        % :param overwrite: whether to overwrite existing data (default: true), or append
-        % :type overwrite: logical
+        % Load data from file
+        % loadData(filepath, _)
+        %
+        % Arguments
+        % ---------
+        % filepath : char
+        %     JSON file to load from
+        %
+        % Keyword Arguments
+        % -----------------
+        % overwrite : logical (default=true)
+        %     Overwrite existing valve data
 
         p = inputParser;
         p.addOptional('overwrite', true, @islogical);

--- a/Functions/+BpodLib/+multi/createMultiSetup.m
+++ b/Functions/+BpodLib/+multi/createMultiSetup.m
@@ -1,9 +1,31 @@
 function createMultiSetup(BpodSystem)
-%createMultiSetup(BpodSystem)
-%   This function creates a new multi setup for the Bpod system.
-%   It either converts an existing single-setup folder structure to a multi-setup compatible one
-%   by moving the existing files, or creates a "fresh" setup by copying in example files to where
-%   the BpodSystem COM's configuration files are expected.
+% Create a new multi setup inside Bpod Local/
+% createMultiSetup(BpodSystem)
+%
+% This function creates a new multi setup for the Bpod system.
+% It either converts an existing single-setup folder structure to a multi-setup compatible one
+% by moving the existing files, or creates a "fresh" setup by copying in example files to where
+% the BpodSystem COM's configuration files are expected.
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 if BpodLib.path.compatibility.isLegacySettings(BpodSystem.Path.LocalDir)
     error('BpodLib:MultiSetup:LegacyIncompatible', 'Legacy setups must first be converted to modern setup with Config/ folder.')

--- a/Functions/+BpodLib/+multi/isMultiSetup.m
+++ b/Functions/+BpodLib/+multi/isMultiSetup.m
@@ -1,12 +1,41 @@
 function result = isMultiSetup(varargin)
-%result = BpodLib.multi.isMultiSetup(BpodSystem, _)
 % Determine if the system is being run on a computer with multiple state machines attached.
-% BpodSystem is required to be passed in if 'LocalDir' is not specified.
+% result = BpodLib.multi.isMultiSetup(BpodSystem, _)
+%
+% Arguments
+% ---------
+% BpodSystem : BpodObject
+%     Optional, but is required to be passed in if 'LocalDir' is not specified.
+%
+% Keyword Arguments
+% -----------------
+% LocalDir : char
+%     Location of Bpod Local/
 %
 % Examples
 % --------
 % result = BpodLib.multi.isMultiSetup(BpodSystem)
 % result = BpodLib.multi.isMultiSetup('LocalDir', '/path/to/local/dir')
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 p = inputParser();
 p.addOptional('BpodSystem', [], @(x) isempty(x) | isstruct(x) | isa(x, 'BpodObject') | isa(x, 'BpodLib.BpodObject.MockBpodObject'))

--- a/Functions/+BpodLib/+path/+compatibility/isLegacySettings.m
+++ b/Functions/+BpodLib/+path/+compatibility/isLegacySettings.m
@@ -1,6 +1,35 @@
 function islegacy =  isLegacySettings(LocalDir)
-%islegacy = isLegacySettings(LocalDir)
 % Check if the settings directory is a legacy one
+% islegacy = isLegacySettings(LocalDir)
+%
+% Arguments
+% ---------
+% LocalDir : char
+%     Path to Bpod Local/
+%
+% Returns
+% -------
+% islegacy : logical
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 islegacy = false;
 

--- a/Functions/+BpodLib/+path/getPath.m
+++ b/Functions/+BpodLib/+path/getPath.m
@@ -1,27 +1,57 @@
 function path = getPath(target, varargin)
-%path = getPath(target, _)
 % Retrieve the path to something
-% Example usages:
+% path = getPath(target, _)
+%
+% Examples
+% --------
 % path = getPath('liquidcalibration', BpodSystem, 'setuptype', 'single')
 % path = getPath('config', 'LocalDir', LocalDirPath, 'setuptype', 'multi', 'com', 'COM3')
 %
-% :param target: The target path to retrieve, can be one of the following:
-%   - 'config': Path to the config folder
-%   - 'local': Path to the local directory
-%   - 'liquidcalibration': Path to the liquid calibration files
-%   - 'root': Path to the Bpod root directory
-%   - 'settings': Path to the settings folder
-% :type target: char
-% :param BpodSystem: The Bpod system object, if not provided you must specify 'LocalDir' parameterfe
-% :type BpodSystem: BpodObject or struct
-% :param setuptype: What kind of setup (single/multi) to find path for, defaults to auto-detecting
-% :type setuptype: char
-% :param LocalDir: The local directory to use, if not provided uses BpodSystem.Path.LocalDir. This overrides auto-detection of LocalDir from BpodSystem.
-% :type LocalDir: char
-% :param com: The COM port to use for multi setups, if not provided uses BpodSystem.SerialPort.PortName
-% :type com: char
-% :return path: The path to the requested target
-% :rtype: char
+% Arguments
+% ---------
+% target : char
+%     The target path to retrieve, can be one of the following:
+%         - 'config': Path to the config folder
+%         - 'local': Path to the local directory
+%         - 'liquidcalibration': Path to the liquid calibration files
+%         - 'root': Path to the Bpod root directory
+%         - 'settings': Path to the settings folder
+% BpodSystem : BpodObject or struct
+%     Optional, if not provided you must specify 'LocalDir' keyword argument
+%
+% Keyword Argument
+% ----------------
+% setuptype : char
+%     What kind of setup (single/multi) to find path for, defaults to auto-detecting
+% LocalDir : char
+%     The local directory to use, if not provided uses BpodSystem.Path.LocalDir. This overrides auto-detection of LocalDir from BpodSystem.
+% com : char
+%     The COM port to use for multi setups, if not provided uses BpodSystem.SerialPort.PortName
+%
+% Returns
+% -------
+% path : char
+%     The path to the requested target
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 p = inputParser();
 p.addOptional('BpodSystem', [], @(x) isempty(x) || isstruct(x) || isa(x, 'BpodObject') || isa(x, 'BpodLib.BpodObject.MockBpodObject'))

--- a/Functions/+BpodLib/+path/verifyPathing.m
+++ b/Functions/+BpodLib/+path/verifyPathing.m
@@ -1,6 +1,45 @@
 function verified = verifyPathing(BpodSystem, varargin)
-% verified = verifyPathing(BpodSystem)
 % Verify that the expected pathing exists for the BpodSystem
+% verified = verifyPathing(BpodSystem)
+
+% docstring
+% signature
+%
+% Arguments
+% ---------
+% BpodSystem : BpodObject
+%
+% Keyword Arguments
+% -----------------
+% ThrowErrors : logical (default=true)
+%     Whether to throw errors if verification fails.
+% verbose : logical (default=true)
+%     Whether to display messages in Command Window.
+%
+% Returns
+% -------
+% verified : logical
+%     Returns true if successful, 0 otherwise
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 p = inputParser();
 p.addParameter('ThrowErrors', true)

--- a/Functions/+BpodLib/+ui/raise.m
+++ b/Functions/+BpodLib/+ui/raise.m
@@ -1,0 +1,45 @@
+function result = raise(UIObject)
+% Focus/raise a figure object is possible.
+% result = raise(UIObject)
+%
+% Arguments
+% ---------
+% UIObject : object
+%     Object in BpodLib used to maintain a figure window
+%
+% Returns
+% -------
+% result : bool
+%     Returns true if successful, false otherwise
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
+result = false;
+objFigure = UIObject.GUIHandles.Figure;
+
+if ~isvalid(objFigure)
+    return
+end
+
+figure(objFigure)
+result = true;
+
+end

--- a/Functions/+BpodLib/+utils/+log/startupMessage.m
+++ b/Functions/+BpodLib/+utils/+log/startupMessage.m
@@ -1,5 +1,26 @@
 function message = startupMessage()
-%STARTUPMESSAGE Displays a startup message when Bpod is initialized.
+% Displays a startup message when Bpod is initialized.
+% message = startupMessage()
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 message = sprintf('** Starting Bpod Console v%s **\nInitialized: %s', BpodSoftwareVersion_Semantic, BpodLib.utils.isotime());
 % todo: add datetime and git head 

--- a/Functions/+BpodLib/+utils/getBpodSystem.m
+++ b/Functions/+BpodLib/+utils/getBpodSystem.m
@@ -2,8 +2,35 @@ function BpodSystem = getBpodSystem(parsedinputs)
 % Retrieve BpodSystem from an input parser
 % This function allows custom BpodSystems to be passed by argument
 % 
-% :param parsedinputs: An inputParser that has BpodSystem as an argument
-% :type parsedinputs: inputParser
+% Arguments
+% ---------
+% parsedinputs : inputParser
+%     An inputParser that has BpodSystem as an argument
+%
+% Returns
+% ------
+% BpodSystem : BpodObject
+%     The object
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 results = parsedinputs.Results;
 

--- a/Functions/+BpodLib/+utils/getCurrentCOM.m
+++ b/Functions/+BpodLib/+utils/getCurrentCOM.m
@@ -1,6 +1,38 @@
 function comport = getCurrentCOM(BpodSystem)
 % Return the name of the current COM
+% comport = getCurrentCOM(BpodSystem)
+%
 % Will return 'EMU' if emulator mode, otherwise 'COMX'
+% Linux dev/ttyUSB is converted to COM
+%
+% Arguments
+% ---------
+% BpodSystem : BpodObject
+%
+% Returns
+% -------
+% comport : char
+%     'COMX' or 'EMU'
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 if isempty(BpodSystem.SerialPort)
     comport = 'EMU';

--- a/Functions/+BpodLib/+utils/isotime.m
+++ b/Functions/+BpodLib/+utils/isotime.m
@@ -1,9 +1,37 @@
 function datestring = isotime(varargin)
-% Get the current time in ISO format
-% :param format: the format of the output string, either 'datetime' (default), 'iso8601', 'date', or 'time'
-% :type format: char
-% :return datestring: the current time in format ready for char/JSON encoding/display
-% :rtype datestring: datetime
+% Get the current date and/or time
+% datestring = isotime(varargin)
+%
+% Arguments
+% ---------
+% format : char
+%     Format of the output string, either 'datetime' (default), 'iso8601', 'date', or 'time'
+%
+% Returns
+% -------
+% datestring : datetime
+%     Current time in format ready for char/JSON encoding/display
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
 datestring = datetime('now', 'Format', 'yyyy-MM-dd HH:mm:ss');
 
 if isempty(varargin)

--- a/Tests/BpodLib/BpodObject/setup/test_legacySetup.m
+++ b/Tests/BpodLib/BpodObject/setup/test_legacySetup.m
@@ -87,7 +87,7 @@ function test_conversionCongruence(testCase)
     % Now test to see if Bpod Local/ and Bpod Local New/ are the same
     convertedFiles = dir(fullfile(testCase.TestData.BpodSystem.Path.LocalDir, 'Config/*.*'));
     newFiles = dir(fullfile(BpodSystemNew.Path.LocalDir, 'Config/*.*'));
-    testCase.verifyEqual(numel(convertedFiles) - 2, numel(newFiles), 'Number of files in Config folder after conversion does not match the new setup.');
+    testCase.verifyEqual(numel(convertedFiles) - 1, numel(newFiles), 'Number of files in Config folder after conversion does not match the new setup.');
     for idx = 1:numel(newFiles)
         if convertedFiles(idx).isdir
             continue

--- a/Tests/BpodSystemTests/test_liquidcalibrator.m
+++ b/Tests/BpodSystemTests/test_liquidcalibrator.m
@@ -36,9 +36,9 @@ function setup(testCase)
     mkdir(localdir)
     mkdir(fullfile(localdir, 'Calibration Files'))
     mkdir(fullfile(localdir, 'Settings'))
-    mkdir(fullfile(localdir, 'Config'))
-    copyfile('../BpodLib/calibration/liquid/testData/ExpectedLiquidCalibration.json', fullfile(localdir, 'Config/LiquidCalibration.json'))
-    copyfile('../BpodLib/calibration/liquid/testData/LiquidCalibration.mat', fullfile(localdir, 'Calibration Files/OLD LiquidCalibration.mat'))
+%     mkdir(fullfile(localdir, 'Config'))
+%     copyfile('../BpodLib/calibration/liquid/testData/ExpectedLiquidCalibration.json', fullfile(localdir, 'Config/LiquidCalibration.json'))
+    copyfile('../BpodLib/calibration/liquid/testData/LiquidCalibration.mat', fullfile(localdir, 'Calibration Files/LiquidCalibration.mat'))
     BpodSystem.CalibrationTables.LiquidCal = BpodLib.calibration.liquid.io.load('BpodSystem', BpodSystem, 'type', 'statemachine');
 end
 
@@ -51,7 +51,7 @@ function test_RunCalibration(testCase)
     % Test users running a calibration
 
     global BpodSystem
-    
+    BpodLib.calibration.liquid.compatibility.conversionscript(BpodSystem, 'verbose', false);
     % Make sure there's no existing liquid calibration window when about to
     % start test
     if isfield(BpodSystem.GUIHandles, 'LiquidCalibrator') && ~isempty(BpodSystem.GUIHandles.LiquidCalibrator)
@@ -108,9 +108,6 @@ function test_GUItransfer(testCase)
     % Prepare the liquid calibration folder
     global BpodSystem
     calFolder = fullfile(BpodSystem.Path.LocalDir, 'Calibration Files');
-    convertedCalFolder = fullfile(BpodSystem.Path.LocalDir, 'Config');
-    copyfile(fullfile(calFolder, 'OLD LiquidCalibration.mat'), fullfile(calFolder, 'LiquidCalibration.mat'));
-    copyfile(fullfile(convertedCalFolder, 'LiquidCalibration.json'), fullfile(convertedCalFolder, 'TEMP LiquidCalibration.json'));
     BpodSystem.CalibrationTables.LiquidCal = load(fullfile(calFolder, 'LiquidCalibration.mat'), 'LiquidCal').LiquidCal;
     
     % Test GUI


### PR DESCRIPTION
- Formatting with the style guide.
- Addition of license text to all files.
- Renaming of some variables to maintain consistency across functions.
- Docstrings in `+BpodLib` have been updated to use the NumPy style, as Sphinx's [napoleon extension](https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html) enables this support (if we move to [Sphinx for MATLAB](https://github.com/sphinx-contrib/matlabdomain) at some point).