### PR TITLE
Modify `AddTrialEvents` to handle LiquidCal object

### DIFF
--- a/Functions/AddTrialEvents.m
+++ b/Functions/AddTrialEvents.m
@@ -1,23 +1,3 @@
-%{
-----------------------------------------------------------------------------
-
-This file is part of the Sanworks Bpod repository
-Copyright (C) Sanworks LLC, Rochester, New York, USA
-
-----------------------------------------------------------------------------
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, version 3.
-
-This program is distributed  WITHOUT ANY WARRANTY and without even the 
-implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
-See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-%}
-
 % AddTrialEvents formats trial events returned by RunStateMachine() or BpodTrialManager() 
 % and adds them to a human-readable session data struct. 
 % 
@@ -46,6 +26,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 % Example usage: sd = AddTrialEvents(sd, rawTrialEvents);
 % Note: If BpodSystem.Data is passed as sd, it can be saved to the current data file with SaveBpodSessionData();
 % BpodSystem.Data = AddTrialEvents(BpodSystem.Data,RawEvents);
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
 
 function updatedSD = AddTrialEvents(sd, rawTrialEvents)
 
@@ -97,7 +97,11 @@ else
     
     % Add calibration info
     sd.Info.Calibration = struct;
-    sd.Info.Calibration.Liquid = BpodSystem.CalibrationTables.LiquidCal;
+    LiquidCal = BpodSystem.CalibrationTables.LiquidCal;
+    if isa(LiquidCal, 'BpodLib.calibration.liquid.ValveDataManagerClass')
+        LiquidCal = LiquidCal.createSaveData();
+    end
+    sd.Info.Calibration.Liquid = LiquidCal;
     sd.Info.Calibration.Sound = BpodSystem.CalibrationTables.SoundCal;
 
     % Add session start time


### PR DESCRIPTION
Rather than saving the `ValveDataManangerClass` object into SessionData, the data format that is fed to `jsonencode` is used.

- [x] Determine if a separate format is more appropriate.
- [x] Test functionality.