### PR TITLE
Live plot of state matrix and event progress

### DIFF
--- a/Functions/+BpodLib/+ui/+utils/setDarkMode.m
+++ b/Functions/+BpodLib/+ui/+utils/setDarkMode.m
@@ -1,0 +1,80 @@
+function setDarkMode(ax)
+% Apply dark mode styling to axes and its children
+% setDarkMode(ax) configures the axes with a dark color scheme
+%
+% Input:
+%       ax - Axes handle or figure handle to modify
+
+% Define colors
+dark_bg = [0.1 0.1 0.1];    % Dark background
+light_text = [0.9 0.9 0.9]; % Light text/line color
+grid_color = [0.3 0.3 0.3]; % Subdued grid color
+
+% Check if input is figure or axes
+if strcmp(get(ax,'Type'), 'figure')
+    fig = ax;
+    ax = findobj(fig, 'Type', 'axes');
+else
+    fig = ancestor(ax, 'figure');
+end
+
+% Set figure properties
+set(fig, ...
+    'Color', dark_bg, ...
+    'InvertHardcopy', 'off'); % Preserve colors when printing
+
+% Set axes properties
+set(ax, ...
+    'Color', dark_bg, ...
+    'XColor', light_text, ...
+    'YColor', light_text, ...
+    'ZColor', light_text, ...
+    'GridColor', grid_color, ...
+    'MinorGridColor', grid_color, ...
+    'GridAlpha', 0.5, ...
+    'MinorGridAlpha', 0.2);
+
+% Set title and labels
+title_handle = get(ax, 'Title');
+xlabel_handle = get(ax, 'XLabel');
+ylabel_handle = get(ax, 'YLabel');
+zlabel_handle = get(ax, 'ZLabel');
+
+set([title_handle, xlabel_handle, ylabel_handle, zlabel_handle], ...
+    'Color', light_text);
+
+% todo: this modifies the patchs behind axes
+% Modify all children (lines, patches, etc.)
+% children = findobj(ax, '-property', 'Color');
+% for i = 1:length(children)
+%     try
+%         % Skip if it's a histogram (special case)
+%         if ~isa(children(i), 'matlab.graphics.chart.primitive.Histogram')
+%             set(children(i), 'Color', light_text);
+%         end
+%     catch
+%         continue
+%     end
+% end
+
+% Set colormap to something that works well with dark background
+colormap(ax, 'parula'); % or 'viridis', 'plasma'
+
+% If there's a legend, update its colors
+leg = findobj(fig, 'Type', 'legend');
+if ~isempty(leg)
+    set(leg, ...
+        'TextColor', light_text, ...
+        'Color', dark_bg, ...
+        'EdgeColor', grid_color);
+end
+
+% If there's a colorbar, update it
+cb = findobj(fig, 'Type', 'colorbar');
+if ~isempty(cb)
+    set(cb, ...
+        'Color', light_text, ...
+        'YColor', light_text, ...
+        'XColor', light_text);
+end
+end

--- a/Functions/+BpodLib/+vis/+lick/calculateStateLineData.m
+++ b/Functions/+BpodLib/+vis/+lick/calculateStateLineData.m
@@ -1,0 +1,45 @@
+function [times, states] = calculateStateLineData(portins, portouts, endtime)
+% Build plot() ready lick line data
+% [times, states] = calculateStateLineData(portins, portouts, endtime)
+%
+% portins and portouts are expected to be the output of cleanPortTimes()
+% plot(times, states) will generate a line in up state during lick
+%
+% Arguments
+% ---------
+% portins : double
+%     Port in times
+% portouts : double
+%     Port out times, numel() same as portins
+% endtime : double
+%     A single time to draw the end of the line to
+%
+% Returns
+% -------
+% times : double
+%     Times of events
+% states : double
+%     State of port (1 or 0)
+
+% Add 1 for licking, 0 for not licking
+data = [[ones(size(portins)) zeros(size(portouts))] ; [portins, portouts]];
+
+% Sort port events according to time
+[~, idx] = sort(data(2,:));
+data = data(:,idx);
+
+% If no lick literally at start of trial:
+% The opposite state to the first recorded was at time 0
+if data(2,1) ~= 0 % checks if there's event at time 0
+    data = [[mod(1,data(1,1));0], data];
+end
+
+% The end state continues to the endtime
+% e.g. if the portout never happens then the state remained in/high
+if data(2,end) ~= endtime
+    data = [data [data(1,end); endtime]];
+end
+
+times = data(2, :);
+states = data(1, :);
+end

--- a/Functions/+BpodLib/+vis/+lick/cleanPortTimes.m
+++ b/Functions/+BpodLib/+vis/+lick/cleanPortTimes.m
@@ -1,0 +1,24 @@
+function [portins, portouts] = cleanPortTimes(portins, portouts)
+% Cleanse port data
+% [portins, portouts] = cleanPortTimes(portins, portouts)
+%
+% 
+
+if ~isempty(portins)
+    if isempty(portouts)
+        portouts = NaN;
+    end
+    
+    % Handle edge cases
+    if portins(1) > portouts(1) % an out before an in
+        portins = [NaN portins];
+    end
+    if portins(end) > portouts(end) % in before trial end
+        portouts(end + 1) = NaN;
+    end
+elseif ~isempty(portouts)
+    portins = NaN;
+else
+    portins = [];
+    portouts = [];
+end

--- a/Functions/@BpodObject/BpodObject.m
+++ b/Functions/@BpodObject/BpodObject.m
@@ -45,6 +45,7 @@ classdef BpodObject < handle
         LastStateMatrix % Last state matrix completed. This is updated each time a trial run completes.
         HardwareState % Current state of I/O lines and serial codes
         StateMachineInfo % Struct with information about state machines (customized for connected hardware)
+        StateHandlerFunction % function handle to run 
         GUIHandles % Struct with graphics handles
         GUIData % Struct with graphics data
         InputsEnabled % Struct storing input channels that are connected to something. This is modified from the settings menu UI.

--- a/Functions/Internal Functions/RunBpodEmulator.m
+++ b/Functions/Internal Functions/RunBpodEmulator.m
@@ -140,6 +140,7 @@ switch op
 
             % Evaluate state timer transitions
             timeInState = BpodSystem.Emulator.CurrentTime - BpodSystem.Emulator.StateStartTime;
+            BpodSystem.Emulator.timeInState = timeInState;
             stateTimer = BpodSystem.StateMatrix.StateTimers(BpodSystem.Emulator.CurrentState);
             if (timeInState > stateTimer) && (BpodSystem.Emulator.MeaningfulTimer(BpodSystem.Emulator.CurrentState) == 1)
                 BpodSystem.Emulator.nCurrentEvents = BpodSystem.Emulator.nCurrentEvents + 1;

--- a/Functions/Plugins/Plots/LiveStatePlot.m
+++ b/Functions/Plugins/Plots/LiveStatePlot.m
@@ -167,21 +167,21 @@ methods
         stateTimes = [0 stateTimes currentTime];
         stateindices = [stateindices stateindices(end)];
 
-        % if ~isempty(obj.settings.defaultMaxTime)
-        %     if (currentTime + obj.settings.leadTime) > obj.settings.defaultMaxTime
-        %         xLimMax = currentTime + obj.settings.leadTime;
-        %     else
-        %         xLimMax = obj.settings.defaultMaxTime;
-        %     end
-        % else
-        %     xLimMax = currentTime + obj.settings.leadTime;
-        % end
+        if ~isempty(obj.settings.defaultMaxTime)
+            if (currentTime + obj.settings.leadTime) > obj.settings.defaultMaxTime
+                xLimMax = currentTime + obj.settings.leadTime;
+            else
+                xLimMax = obj.settings.defaultMaxTime;
+            end
+        else
+            xLimMax = currentTime + obj.settings.leadTime;
+        end
         % Update plot
         set(obj.GUIHandles.PlotState, ...
             'XData', stateTimes, ...
             'YData', stateindices);
-        % set(obj.GUIHandles.AxesState,...
-            % 'XLim', [0, xLimMax]);
+        set(obj.GUIHandles.AxesState,...
+            'XLim', [0, xLimMax]);
         obj.update_events(eventTimes, obj.BpodSystem.Status.events(obj.BpodSystem.Status.events ~= 0))
 
         obj.lastTic = tic;

--- a/Functions/Plugins/Plots/LiveStatePlot.m
+++ b/Functions/Plugins/Plots/LiveStatePlot.m
@@ -140,33 +140,38 @@ methods
             return
         end
 
-        % Calculate the time offset between the machine and computer
-        eventTimes = obj.BpodSystem.Status.liveEventTimestamps(obj.BpodSystem.Status.liveEventTimestamps ~= 0);
+        % Retrieve a timestamp for each recorded event
         if obj.BpodSystem.EmulatorMode == 0
-            eventTimes = eventTimes / 1000;
+            eventTimes = obj.BpodSystem.Status.liveEventTimestamps(obj.BpodSystem.Status.liveEventTimestamps ~= 0) / 1000;
         else
-            eventTimes = cumsum(eventTimes);
+            eventTimes = obj.BpodSystem.Emulator.Timestamps(obj.BpodSystem.Emulator.Timestamps ~= 0);
         end
         
+        % Calculate the time offset between the machine and computer
         currentTime = toc(obj.trialStartTic);
         if numel(eventTimes) > obj.lastNEvents  % If there is a new event
             obj.lastNEvents = numel(eventTimes);
             % Calculate difference between machine's time and toc() time
             obj.timeDiff = eventTimes(end) - currentTime;
         end
-        
-        % -- Build state index and times
         currentTime = currentTime + obj.timeDiff;
-
+        
+        % Build state index and times
         stateindices = obj.BpodSystem.Status.states(obj.BpodSystem.Status.states ~= 0);
 
         stateChangeIndexes = obj.BpodSystem.Status.stateChangeIndexes(obj.BpodSystem.Status.stateChangeIndexes ~= 0);
         stateTimes = eventTimes(stateChangeIndexes);
 
-        % Build stairs-compatible x/y data
+        % Build stairs-compatible x/y data with state line continuing to current time
         stateTimes = [0 stateTimes currentTime];
         stateindices = [stateindices stateindices(end)];
 
+        % Update plot
+        set(obj.GUIHandles.PlotState, ...
+            'XData', stateTimes, ...
+            'YData', stateindices);
+
+        % Maintain time window limits
         if ~isempty(obj.settings.defaultMaxTime)
             if (currentTime + obj.settings.leadTime) > obj.settings.defaultMaxTime
                 xLimMax = currentTime + obj.settings.leadTime;
@@ -176,10 +181,6 @@ methods
         else
             xLimMax = currentTime + obj.settings.leadTime;
         end
-        % Update plot
-        set(obj.GUIHandles.PlotState, ...
-            'XData', stateTimes, ...
-            'YData', stateindices);
         set(obj.GUIHandles.AxesState,...
             'XLim', [0, xLimMax]);
         obj.update_events(eventTimes, obj.BpodSystem.Status.events(obj.BpodSystem.Status.events ~= 0))

--- a/Functions/Plugins/Plots/LiveStatePlot.m
+++ b/Functions/Plugins/Plots/LiveStatePlot.m
@@ -1,0 +1,211 @@
+% Plugin for drawing a live update of trial
+% obj = LiveStatePlot(_)
+% 
+% Arguments
+% ---------
+% BpodSystem : BpodObject
+%     BpodSystem, optional (defaults)
+%
+% Keyword Arguments
+% -----------------
+% darkmode : bool
+%     Make the plot dark mode, default true
+% autoclose : bool
+%     Close the figure window at the end of session, default true
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
+classdef LiveStatePlot < handle
+properties
+    GUIHandles
+    BpodSystem
+    lastTic % The last time of update
+    trialStartTic
+    lastNEvents
+    timeDiff
+
+    settings
+    maxDrawHz
+end
+methods
+    function obj = LiveStatePlot(varargin)
+        p = inputParser();
+        p.addOptional('BpodSystem', [])
+        p.addParameter('darkmode', true)
+        p.addParameter('autoclose', true)
+        p.parse(varargin{:})
+        if isempty(p.Results.BpodSystem)
+            global BpodSystem
+        else
+            BpodSystem = p.Results.BpodSystem;
+        end
+        obj.settings = struct();
+        obj.settings.darkmode = p.Results.darkmode;
+        obj.settings.defaultMaxTime = [];
+        obj.settings.leadTime = 3;
+
+        % Build axes
+        obj.BpodSystem = BpodSystem;
+        obj.GUIHandles.Figure = figure('Name', 'LivePlot', 'MenuBar', 'none', 'NumberTitle', 'off');
+        if p.Results.autoclose
+            obj.BpodSystem.ProtocolFigures.LivePlot = obj;
+        else
+            obj.BpodSystem.GUIHandles.LivePlot = obj;
+        end
+        xpos = 0.2;
+        obj.GUIHandles.AxesState = axes(obj.GUIHandles.Figure, 'Position', [xpos, .5, 1-xpos-.1, .2]);
+        obj.GUIHandles.AxesEvent = axes(obj.GUIHandles.Figure, 'Position', [xpos, 0, 1-xpos-.1, .2]);
+        obj.GUIHandles.PlotState = stairs(obj.GUIHandles.AxesState, 0, 0); % if stairs initialises with [] data then it won't update
+        obj.GUIHandles.PlotEvent = scatter(obj.GUIHandles.AxesEvent, [], []);
+        obj.apply_style()
+        
+        obj.lastTic = tic;
+        obj.lastNEvents = [];
+        obj.timeDiff = .8; % todo: seems a reasonable time
+        obj.maxDrawHz = 60;
+    end
+
+    function apply_style(obj)
+        % Sets axes and plot styling
+
+        xpos = .2;
+        set(obj.GUIHandles.AxesState,...
+            'Position', [xpos, .5, 1-xpos, .5]);
+        set(obj.GUIHandles.AxesEvent,...
+            'Position', [xpos, .1, 1-xpos, .4]);
+        
+        % -- Set colors
+        if obj.settings.darkmode
+            color = 'w';
+        else
+            color = 'k';
+        end
+        set(obj.GUIHandles.PlotState,...
+            'Color', color, ...
+            'Marker', '.')
+        set(obj.GUIHandles.PlotEvent,...
+            'Color', color,...
+            'Marker', '|')
+        grid(obj.GUIHandles.AxesState, 'on')
+        grid(obj.GUIHandles.AxesEvent, 'on')
+
+        for ax = {obj.GUIHandles.AxesState, obj.GUIHandles.AxesEvent}
+            if obj.settings.darkmode
+                BpodLib.ui.utils.setDarkMode(ax{1})
+            end
+        end
+
+        % Y labels (states and events) are set in obj.newTrial()
+        
+    end
+
+    function close(obj)
+        close(obj.GUIHandles.Figure);
+    end
+
+    function update(obj, operation)
+        switch operation
+            case 'trial_start'
+                obj.newTrial()
+                return
+            case 'trial_end'
+                return
+        end
+
+        % Calculate the time offset between the machine and computer
+        eventTimes = obj.BpodSystem.Status.liveEventTimestamps(obj.BpodSystem.Status.liveEventTimestamps ~= 0);
+        eventTimes = cumsum(eventTimes);
+        currentTime = toc(obj.trialStartTic);
+        if numel(eventTimes) > obj.lastNEvents  % If there is a new event
+            obj.lastNEvents = numel(eventTimes);
+            % Calculate difference between machine's time and toc() time
+            obj.timeDiff = eventTimes(end) - currentTime;
+        end
+
+        % Limit rate the plot update
+        if toc(obj.lastTic) < 1/obj.maxDrawHz
+            return
+        end
+
+        % -- Build state index and times
+        currentTime = currentTime + obj.timeDiff;
+
+        stateindices = obj.BpodSystem.Status.states(obj.BpodSystem.Status.states ~= 0);
+
+        stateChangeIndexes = obj.BpodSystem.Status.stateChangeIndexes(obj.BpodSystem.Status.stateChangeIndexes ~= 0);
+        stateTimes = eventTimes(stateChangeIndexes);
+
+        % Build stairs-compatible x/y data
+        stateTimes = [0 stateTimes currentTime];
+        stateindices = [stateindices stateindices(end)];
+
+        % if ~isempty(obj.settings.defaultMaxTime)
+        %     if (currentTime + obj.settings.leadTime) > obj.settings.defaultMaxTime
+        %         xLimMax = currentTime + obj.settings.leadTime;
+        %     else
+        %         xLimMax = obj.settings.defaultMaxTime;
+        %     end
+        % else
+        %     xLimMax = currentTime + obj.settings.leadTime;
+        % end
+        % Update plot
+        set(obj.GUIHandles.PlotState, ...
+            'XData', stateTimes, ...
+            'YData', stateindices);
+        % set(obj.GUIHandles.AxesState,...
+            % 'XLim', [0, xLimMax]);
+        obj.update_events(eventTimes, obj.BpodSystem.Status.events(obj.BpodSystem.Status.events ~= 0))
+
+        obj.lastTic = tic;
+    end
+
+    function update_events(obj, eventTimes, eventIndexes)
+        times = eventTimes;
+        ydata = eventIndexes;
+        % todo: enable custom specification of focus events
+        % todo: build pulse traces for port events
+
+        set(obj.GUIHandles.PlotEvent,...
+            'XData', times,...
+            'YData', ydata)
+        set(obj.GUIHandles.AxesEvent,...
+            'XLim', get(obj.GUIHandles.AxesState, 'XLim'));
+    end
+
+    function newTrial(obj)
+        obj.lastNEvents = 0;
+        obj.trialStartTic = tic;
+
+        % -- Prepare state axes
+        stateNames = obj.BpodSystem.StateMatrix.StateNames; % initialised only when SendStateMatrix() is used...
+        set(obj.GUIHandles.AxesState,...
+            'YTick', 1:numel(stateNames), ...
+            'YTickLabel', stateNames,...
+            'YLim', [-0.5, numel(stateNames) + .5])
+        % obj.timeDiff = % todo: this could be calculated from trialStartTimestamp ?
+
+        % -- Prepare event axes
+        % Determine which events are even valid?
+        
+    end
+end
+end
+

--- a/Functions/Plugins/Plots/LiveStatePlot.m
+++ b/Functions/Plugins/Plots/LiveStatePlot.m
@@ -79,7 +79,7 @@ methods
         
         obj.lastTic = tic;
         obj.lastNEvents = [];
-        obj.timeDiff = .8; % todo: seems a reasonable time
+        obj.timeDiff = 0;
         obj.maxDrawHz = 60;
     end
 
@@ -130,21 +130,31 @@ methods
                 return
         end
 
+        % Limit rate the plot update
+        if toc(obj.lastTic) < 1/obj.maxDrawHz
+            return
+        end
+
+        if ~isvalid(obj.GUIHandles.Figure)
+            assert(obj.BpodSystem.Status.BeingUsed == 0)
+            return
+        end
+
         % Calculate the time offset between the machine and computer
         eventTimes = obj.BpodSystem.Status.liveEventTimestamps(obj.BpodSystem.Status.liveEventTimestamps ~= 0);
-        eventTimes = cumsum(eventTimes);
+        if obj.BpodSystem.EmulatorMode == 0
+            eventTimes = eventTimes / 1000;
+        else
+            eventTimes = cumsum(eventTimes);
+        end
+        
         currentTime = toc(obj.trialStartTic);
         if numel(eventTimes) > obj.lastNEvents  % If there is a new event
             obj.lastNEvents = numel(eventTimes);
             % Calculate difference between machine's time and toc() time
             obj.timeDiff = eventTimes(end) - currentTime;
         end
-
-        % Limit rate the plot update
-        if toc(obj.lastTic) < 1/obj.maxDrawHz
-            return
-        end
-
+        
         % -- Build state index and times
         currentTime = currentTime + obj.timeDiff;
 

--- a/Functions/RunStateMachine.m
+++ b/Functions/RunStateMachine.m
@@ -42,7 +42,7 @@ function rawTrialEvents = RunStateMachine
 global BpodSystem % Import the global BpodSystem object
 
 % Setup
-timeScaleFactor = (BpodSystem.HW.CyclePeriod/1000); % To convert state machine cycles to seconds
+timeScaleFactor = (BpodSystem.HW.CyclePeriod/1000); % To convert state machine cycles to milliseconds
 rawTrialEvents = struct; % Struct for returned trial data
 
 % Ensure that a state machine description has been sent to the device
@@ -78,6 +78,7 @@ BpodSystem.Status.stateChangeIndexes = zeros(1,maxEvents); % Indexes of event ti
 BpodSystem.Status.states(nStates) = 1; % Each trial begins with state 1, the first added with AddState()
 stateNames = BpodSystem.StateMatrix.StateNames; % Local copy of StateNames
 nTotalStates = BpodSystem.StateMatrix.nStatesInManifest; % Local copy of nStates
+activeStateHandlerFunction = ~isempty(BpodSystem.StateHandlerFunction); % todo: ensure doesn't fail on second run of different protocol
 
 % Reset status fields (to be synced with console UI)
 BpodSystem.Status.LastStateCode = 0; % Last state (index)
@@ -121,8 +122,7 @@ else
 end
 update_hardwarestate_new_state(BpodSystem, 1);
 BpodSystem.RefreshGUI;
-if ~isempty(BpodSystem.StateHandlerFunction)
-    % todo: ensure doesn't fail on second run of different protocol
+if activeStateHandlerFunction
     BpodSystem.StateHandlerFunction('trial_start');
 end
 
@@ -166,6 +166,7 @@ while BpodSystem.Status.InStateMatrix
     end
 
     if newMessage % If there are new events or soft codes to read
+        fprintf('New message!%s\n', BpodLib.utils.isotime())
         opCode = opCodeBytes(1);
         switch opCode
             case 1 % Receive and handle events
@@ -173,7 +174,7 @@ while BpodSystem.Status.InStateMatrix
                 if BpodSystem.EmulatorMode == 0
                     if BpodSystem.LiveTimestamps == 1
                         tempCurrentEvents = BpodSystem.SerialPort.read(nCurrentEvents+4, 'uint8');
-                        thisTimestamp = double(typecast(tempCurrentEvents(end-3:end), 'uint32'))*timeScaleFactor;
+                        thisTimestamp = double(typecast(tempCurrentEvents(end-3:end), 'uint32'))*timeScaleFactor; % milliseconds
                         tempCurrentEvents = tempCurrentEvents(1:end-4);
                         % BpodSystem.Status.LastUpdateTime = thisTimestamp;
                     else
@@ -181,7 +182,7 @@ while BpodSystem.Status.InStateMatrix
                     end
                 else
                     tempCurrentEvents = VirtualCurrentEvents;
-                    thisTimestamp = BpodSystem.Emulator.timeInState; % todo: figure out if this is on the same scale as the real state machine's timestamp
+                    thisTimestamp = BpodSystem.Emulator.timeInState;
                 end
                 % Read and convert from c++ index at 0 to MATLAB index at 1
                 currentEvent(1:nCurrentEvents) = tempCurrentEvents(1:nCurrentEvents) + 1; 
@@ -369,14 +370,15 @@ if BpodSystem.Status.BeingUsed == 1 % If exit was due to manual termination, Bei
     rawTrialEvents.ErrorCodes = thisTrialErrorCodes;
 end
 
+if activeStateHandlerFunction
+    BpodSystem.StateHandlerFunction('trial_end');
+end
+
 % Cleanup
 update_hardwarestate_new_state(BpodSystem, 0); % Reset hardware state
 BpodSystem.LastStateMatrix = BpodSystem.StateMatrix;
 BpodSystem.Status.InStateMatrix = 0;
 
-if ~isempty(BpodSystem.StateHandlerFunction)
-    BpodSystem.StateHandlerFunction('trial_end');
-end
 end
 
 function timeOutput = round2cycles(BpodSystem, decimalInput)

--- a/Functions/RunStateMachine.m
+++ b/Functions/RunStateMachine.m
@@ -69,11 +69,13 @@ end
 BpodSystem.StateMatrix = BpodSystem.StateMatrixSent; % Current state machine
 maxEvents = 1000000; % Preallocate anticipating up to 1M events in a single trial.
 nEvents = 0; nStates = 1; % Event and state counters
-events = zeros(1,maxEvents); states = zeros(1,maxEvents);
-liveEventTimestamps = zeros(1,maxEvents); % Timestamps for each event in Events
+BpodSystem.Status.events = zeros(1,maxEvents);
+BpodSystem.Status.states = zeros(1,maxEvents);
+BpodSystem.Status.liveEventTimestamps = zeros(1,maxEvents); % Timestamps for each event in Events
+% todo: remove these from the data once trial finishes?
 currentEvent = zeros(1,100); % A machine refresh can capture up to 100 events
-stateChangeIndexes = zeros(1,maxEvents); % Indexes of event timestamps that triggered state changes
-states(nStates) = 1; % Each trial begins with state 1, the first added with AddState()
+BpodSystem.Status.stateChangeIndexes = zeros(1,maxEvents); % Indexes of event timestamps that triggered state changes
+BpodSystem.Status.states(nStates) = 1; % Each trial begins with state 1, the first added with AddState()
 stateNames = BpodSystem.StateMatrix.StateNames; % Local copy of StateNames
 nTotalStates = BpodSystem.StateMatrix.nStatesInManifest; % Local copy of nStates
 
@@ -119,6 +121,10 @@ else
 end
 update_hardwarestate_new_state(1);
 BpodSystem.RefreshGUI;
+if ~isempty(BpodSystem.StateHandlerFunction)
+    % todo: ensure doesn't fail on second run of different protocol
+    BpodSystem.StateHandlerFunction('trial_start');
+end
 
 % Main loop that runs during trial execution. Events arriving at the USB
 % serial port are logged, and displayed on the console GUI. The current
@@ -169,11 +175,13 @@ while BpodSystem.Status.InStateMatrix
                         tempCurrentEvents = BpodSystem.SerialPort.read(nCurrentEvents+4, 'uint8');
                         thisTimestamp = double(typecast(tempCurrentEvents(end-3:end), 'uint32'))*timeScaleFactor;
                         tempCurrentEvents = tempCurrentEvents(1:end-4);
+                        % BpodSystem.Status.LastUpdateTime = thisTimestamp;
                     else
                         tempCurrentEvents = BpodSystem.SerialPort.read(nCurrentEvents, 'uint8');
                     end
                 else
                     tempCurrentEvents = VirtualCurrentEvents;
+                    thisTimestamp = BpodSystem.Emulator.timeInState; % todo: figure out if this is on the same scale as the real state machine's timestamp
                 end
                 % Read and convert from c++ index at 0 to MATLAB index at 1
                 currentEvent(1:nCurrentEvents) = tempCurrentEvents(1:nCurrentEvents) + 1; 
@@ -215,9 +223,9 @@ while BpodSystem.Status.InStateMatrix
                         end
                     end
                     if  newState <= nTotalStates
-                        stateChangeIndexes(nStates) = nEvents+1;
+                        BpodSystem.Status.stateChangeIndexes(nStates) = nEvents+1;
                         nStates = nStates + 1;
-                        states(nStates) = newState;
+                        BpodSystem.Status.states(nStates) = newState;
                         BpodSystem.Status.LastStateCode = BpodSystem.Status.CurrentStateCode;
                         BpodSystem.Status.CurrentStateCode = newState;
                         BpodSystem.Status.CurrentStateName = stateNames{newState};
@@ -269,17 +277,17 @@ while BpodSystem.Status.InStateMatrix
                         end
                     else
                         if BpodSystem.EmulatorMode == 1
-                            stateChangeIndexes(nStates) = nEvents+1;
-                            events(nEvents+1:(nEvents+nCurrentEvents)) = currentEvent(1:nCurrentEvents);
+                            BpodSystem.Status.stateChangeIndexes(nStates) = nEvents+1;
+                            BpodSystem.Status.events(nEvents+1:(nEvents+nCurrentEvents)) = currentEvent(1:nCurrentEvents);
                             nEvents = nEvents + nCurrentEvents;
                             break
                         end
                     end
                 end
                 if BpodSystem.Status.InStateMatrix == 1
-                    events(nEvents+1:(nEvents+nCurrentEvents)) = currentEvent(1:nCurrentEvents);
-                    if BpodSystem.LiveTimestamps == 1
-                        liveEventTimestamps(nEvents+1:(nEvents+nCurrentEvents)) = thisTimestamp;
+                    BpodSystem.Status.events(nEvents+1:(nEvents+nCurrentEvents)) = currentEvent(1:nCurrentEvents);
+                    if BpodSystem.LiveTimestamps == 1 || BpodSystem.EmulatorMode
+                        BpodSystem.Status.liveEventTimestamps(nEvents+1:(nEvents+nCurrentEvents)) = thisTimestamp;
                     end
                     BpodSystem.Status.LastEvent = currentEvent(1);
                     if serialPortBytesAvailable < 250
@@ -297,6 +305,10 @@ while BpodSystem.Status.InStateMatrix
     else
         drawnow;
     end
+    if ~isempty(BpodSystem.StateHandlerFunction)
+        % todo: ensure doesn't fail on second run of different protocol
+        BpodSystem.StateHandlerFunction('update');
+    end
 end
 
 % Execution continues here after a trial exit state was reached.
@@ -304,9 +316,9 @@ if BpodSystem.Status.BeingUsed == 1 % If exit was due to manual termination, Bei
     % Partial trials are not stored, to ensure data uniformity.
     thisTrialErrorCodes = [];
     % Trim unused preallocated data
-    events = events(1:nEvents);
-    states = states(1:nStates);
-    stateChangeIndexes = stateChangeIndexes(1:nStates-1);
+    BpodSystem.Status.events = BpodSystem.Status.events(1:nEvents);
+    BpodSystem.Status.states = BpodSystem.Status.states(1:nStates);
+    BpodSystem.Status.stateChangeIndexes = BpodSystem.Status.stateChangeIndexes(1:nStates-1);
     
     if BpodSystem.EmulatorMode == 0
         % Read trial-end timestamps.
@@ -327,7 +339,7 @@ if BpodSystem.Status.BeingUsed == 1 % If exit was due to manual termination, Bei
         end
     end
     if BpodSystem.LiveTimestamps == 1 % FSM 0.7 and newer return event timestamps as they are captured
-        timeStamps = liveEventTimestamps(1:nEvents);
+        timeStamps = BpodSystem.Status.liveEventTimestamps(1:nEvents);
     end
     % Read Timestamps
     if BpodSystem.EmulatorMode == 0
@@ -344,12 +356,12 @@ if BpodSystem.Status.BeingUsed == 1 % If exit was due to manual termination, Bei
     % Determine event and state timestamps
     eventTimeStamps = timeStamps;
     stateTimeStamps = zeros(1,nStates);
-    stateTimeStamps(2:nStates) = timeStamps(stateChangeIndexes);
+    stateTimeStamps(2:nStates) = timeStamps(BpodSystem.Status.stateChangeIndexes);
     stateTimeStamps(1) = 0;
 
     % Package trial events, states and timestamps
-    rawTrialEvents.States = states;
-    rawTrialEvents.Events = events;
+    rawTrialEvents.States = BpodSystem.Status.states;
+    rawTrialEvents.Events = BpodSystem.Status.events;
     rawTrialEvents.StateTimestamps = round2cycles(stateTimeStamps)/1000; % Convert to seconds
     rawTrialEvents.EventTimestamps = round2cycles(eventTimeStamps)/1000;
     rawTrialEvents.TrialStartTimestamp = round2cycles(trialStartTimestamp);
@@ -362,6 +374,10 @@ end
 update_hardwarestate_new_state(0); % Reset hardware state
 BpodSystem.LastStateMatrix = BpodSystem.StateMatrix;
 BpodSystem.Status.InStateMatrix = 0;
+
+if ~isempty(BpodSystem.StateHandlerFunction)
+    BpodSystem.StateHandlerFunction('trial_end');
+end
 end
 
 function timeOutput = round2cycles(decimalInput)

--- a/Functions/RunStateMachine.m
+++ b/Functions/RunStateMachine.m
@@ -114,12 +114,12 @@ if BpodSystem.Status.SessionStartFlag == 1 % On first run of session
     end
 end
 if BpodSystem.EmulatorMode == 0
-    trialStartTimestamp = send_trial_start_command;
+    trialStartTimestamp = send_trial_start_command(BpodSystem);
 else
     RunBpodEmulator('init', []);
     BpodSystem.ManualOverrideFlag = 0;
 end
-update_hardwarestate_new_state(1);
+update_hardwarestate_new_state(BpodSystem, 1);
 BpodSystem.RefreshGUI;
 if ~isempty(BpodSystem.StateHandlerFunction)
     % todo: ensure doesn't fail on second run of different protocol
@@ -157,7 +157,7 @@ while BpodSystem.Status.InStateMatrix
     else
         serialPortBytesAvailable = 0;
         if BpodSystem.ManualOverrideFlag == 1
-            manualOverrideEvent = virtual_manual_override(BpodSystem.VirtualManualOverrideBytes);
+            manualOverrideEvent = virtual_manual_override(BpodSystem, BpodSystem.VirtualManualOverrideBytes);
             BpodSystem.ManualOverrideFlag = 0;
         else
             manualOverrideEvent = [];
@@ -215,7 +215,7 @@ while BpodSystem.Status.InStateMatrix
                     end
                     iEvent = iEvent + 1;
                 end
-                update_hardwarestate_new_event(currentEvent);
+                update_hardwarestate_new_event(BpodSystem, currentEvent);
                 if transitionEventFound
                     if BpodSystem.StateMatrix.meta.use255BackSignal == 1
                         if newState == 256
@@ -230,7 +230,7 @@ while BpodSystem.Status.InStateMatrix
                         BpodSystem.Status.CurrentStateCode = newState;
                         BpodSystem.Status.CurrentStateName = stateNames{newState};
                         BpodSystem.Status.LastStateName = stateNames{BpodSystem.Status.LastStateCode};
-                        update_hardwarestate_new_state(newState);
+                        update_hardwarestate_new_state(BpodSystem, newState);
                         if BpodSystem.EmulatorMode == 1
                             BpodSystem.Emulator.CurrentState = newState;
                             BpodSystem.Emulator.StateStartTime = BpodSystem.Emulator.CurrentTime;
@@ -298,15 +298,14 @@ while BpodSystem.Status.InStateMatrix
                 end
             case 2 % Soft-code
                 softCode = opCodeBytes(2);
-                handle_soft_code(softCode);
+                handle_soft_code(BpodSystem, softCode);
             otherwise
                 disp('Error: Invalid op code received')
         end
     else
         drawnow;
     end
-    if ~isempty(BpodSystem.StateHandlerFunction)
-        % todo: ensure doesn't fail on second run of different protocol
+    if activeStateHandlerFunction
         BpodSystem.StateHandlerFunction('update');
     end
 end
@@ -362,16 +361,16 @@ if BpodSystem.Status.BeingUsed == 1 % If exit was due to manual termination, Bei
     % Package trial events, states and timestamps
     rawTrialEvents.States = BpodSystem.Status.states;
     rawTrialEvents.Events = BpodSystem.Status.events;
-    rawTrialEvents.StateTimestamps = round2cycles(stateTimeStamps)/1000; % Convert to seconds
-    rawTrialEvents.EventTimestamps = round2cycles(eventTimeStamps)/1000;
-    rawTrialEvents.TrialStartTimestamp = round2cycles(trialStartTimestamp);
-    rawTrialEvents.TrialEndTimestamp = round2cycles(trialEndTimestamp);
+    rawTrialEvents.StateTimestamps = round2cycles(BpodSystem, stateTimeStamps)/1000; % Convert to seconds
+    rawTrialEvents.EventTimestamps = round2cycles(BpodSystem, eventTimeStamps)/1000;
+    rawTrialEvents.TrialStartTimestamp = round2cycles(BpodSystem, trialStartTimestamp);
+    rawTrialEvents.TrialEndTimestamp = round2cycles(BpodSystem, trialEndTimestamp);
     rawTrialEvents.StateTimestamps(end+1) = rawTrialEvents.EventTimestamps(end);
     rawTrialEvents.ErrorCodes = thisTrialErrorCodes;
 end
 
 % Cleanup
-update_hardwarestate_new_state(0); % Reset hardware state
+update_hardwarestate_new_state(BpodSystem, 0); % Reset hardware state
 BpodSystem.LastStateMatrix = BpodSystem.StateMatrix;
 BpodSystem.Status.InStateMatrix = 0;
 
@@ -380,16 +379,14 @@ if ~isempty(BpodSystem.StateHandlerFunction)
 end
 end
 
-function timeOutput = round2cycles(decimalInput)
+function timeOutput = round2cycles(BpodSystem, decimalInput)
 % Trims precision of timestamps to match state machine refresh interval
-global BpodSystem
 freq = BpodSystem.HW.CycleFrequency;
 timeOutput = round(decimalInput*(freq))/(freq);
 end
 
-function update_hardwarestate_new_state(currentState)
+function update_hardwarestate_new_state(BpodSystem, currentState)
 % Updates BpodSystem.HardwareState to reflect entry into a new state
-global BpodSystem
 if currentState > 0
     newOutputState = BpodSystem.StateMatrix.OutputMatrix(currentState,:);
     outputOverride = BpodSystem.HardwareState.OutputOverride;
@@ -401,9 +398,8 @@ else
 end
 end
 
-function update_hardwarestate_new_event(Events)
+function update_hardwarestate_new_event(BpodSystem, Events)
 % Updates BpodSystem.HardwareState to reflect new event(s).
-global BpodSystem
 nEvents = sum(Events ~= 0);
 for i = 1:nEvents
     thisEvent = Events(i);
@@ -449,16 +445,14 @@ function timeString = secs2hms(seconds)
     timeString = sprintf('%02d:%02d:%02d', h, m, s);
 end
 
-function handle_soft_code(softCode)
+function handle_soft_code(BpodSystem, softCode)
 % Calls the current soft code handler function, passing it the SoftCode
 % received from the state machine
-global BpodSystem
 eval([BpodSystem.SoftCodeHandlerFunction '(' num2str(softCode) ')'])
 end
 
-function manualOverrideEvent = virtual_manual_override(overrideMessage)
+function manualOverrideEvent = virtual_manual_override(BpodSystem, overrideMessage)
 % Converts the byte code transmission formatted for the state machine into event codes
-global BpodSystem
 opCode = overrideMessage(1);
 if opCode == 'V'
     inputChannel = overrideMessage(2)+1;
@@ -475,7 +469,7 @@ if opCode == 'V'
         end
     end
 elseif opCode == 'S'
-    handle_soft_code(uint8(overrideMessage(2)));
+    handle_soft_code(BpodSystem, uint8(overrideMessage(2)));
     manualOverrideEvent = [];
 elseif opCode == '~'
     code = overrideMessage(2);
@@ -490,13 +484,12 @@ else
 end
 end
 
-function trialStartTimestamp = send_trial_start_command
+function trialStartTimestamp = send_trial_start_command(BpodSystem)
 % Sends the trial start command to the Bpod State Machine device.
 % Reads an acknowledgement if a new state machine description was sent
 % previously and successfully received.
 % Returns: TrialStartTimestamp (units = s), trial start time measured by
 % the state machine clock
-global BpodSystem
 BpodSystem.SerialPort.flush;
 BpodSystem.SerialPort.write('R', 'uint8'); % Send the code to run the loaded matrix (character "R" for Run)
 if BpodSystem.Status.NewStateMachineSent % Read confirmation byte = successful state machine transmission

--- a/Functions/RunStateMachine.m
+++ b/Functions/RunStateMachine.m
@@ -287,7 +287,7 @@ while BpodSystem.Status.InStateMatrix
                 end
                 if BpodSystem.Status.InStateMatrix == 1
                     BpodSystem.Status.events(nEvents+1:(nEvents+nCurrentEvents)) = currentEvent(1:nCurrentEvents);
-                    if BpodSystem.LiveTimestamps == 1 || BpodSystem.EmulatorMode
+                    if BpodSystem.LiveTimestamps == 1
                         BpodSystem.Status.liveEventTimestamps(nEvents+1:(nEvents+nCurrentEvents)) = thisTimestamp;
                     end
                     BpodSystem.Status.LastEvent = currentEvent(1);


### PR DESCRIPTION
Work in progress branch with a live updating plot showing progress of state matrix. Similar to `BpodSystem.SoftCodeHandlerFunction`, `BpodSystem.StateHandlerFunction` enables the byte-read loop to run arbitrary code. Hooking into this with an object that accesses the same information used to update the Console's state and event readout allows a live plot of trial progress to be created.

To test it out, in the protocol setup:
```matlab
lu = LiveStatePlot(BpodSystem);
lu.settings.defaultMaxTime = 10; % set the starting window width as 10 seconds
BpodSystem.StateHandlerFunction = @lu.update;
```

The key change is that some of `RunStateMachine` internal variables (e.g. event codes and timings) have been exposed in `BpodSystem.Status` for access during the trial.

- [x] Modify `RunStateMachine` to call a function handle when checking for state machine codes.
- [ ] Modify `TrialManagerObject`
- [x] Create live state plot
- [ ] Create live event plot
  - [ ] Configurable focus events (there are like 100 possible events for a state machine)
  - [ ] Lick lines
- [ ] Create trial outcome/state entry notifier plugin
- [ ] Test performance and optimise
- [x] Test on physical state machine
- [ ] Create unit tests
  - [ ] Testing of new functions and classes
  - [ ] Create new protocol run testing