### PR TITLE
Fix 2025a multiline uicontrol string issue

### DIFF
--- a/Functions/+BpodLib/+BpodObject/+ui/+compability/createMultiLine.m
+++ b/Functions/+BpodLib/+BpodObject/+ui/+compability/createMultiLine.m
@@ -1,0 +1,46 @@
+function formattedText = createMultiLine(cellText, varargin)
+% Format multiline text destined for uicontrol objects
+% formattedText = createMultiLine(cellText)
+%
+% Arguments
+% ---------
+% cellText : cell
+%     Cell of chars/strings that you want to display in multiple lines
+%
+% Returns
+% -------
+% formattedText : char
+%     Returns char appropriately
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
+if verLessThan('matlab', '25')
+    textFormat = repmat('%s<br>', 1, numel(cellText));
+    textFormat = textFormat(1:end-4);  % remove trailing <br>
+    cellText = sprintf(textFormat, cellText{:});
+
+    formattedText = ['<html>' cellText '</html>'];
+else
+    textFormat = repmat('%s\n', 1, numel(cellText));
+    textFormat = textFormat(1:end-2);
+
+    formattedText = sprintf(textFormat, cellText{:});
+end

--- a/Functions/+BpodLib/+BpodObject/+ui/formatPanelDisplayName.m
+++ b/Functions/+BpodLib/+BpodObject/+ui/formatPanelDisplayName.m
@@ -1,0 +1,75 @@
+function formattedPanelName = formatPanelDisplayName(moduleName)
+% Format module name for Console display in uicontrol
+% formattedPanelName = formatPanelDisplayName(moduleName)
+%
+% MATLAB's undocumented support for HTML in uicontrol apparently ended in
+% 2025 and \n in older versions behaves differently so a compatibility
+% function is required
+%
+% Arguments
+% ---------
+% moduleName : char
+%     Name of module
+%
+% Returns
+% -------
+% formattedPanelName : char
+%     Name with version compatible split into two lines
+
+%{
+----------------------------------------------------------------------------
+
+This file is part of the Sanworks Bpod repository
+Copyright (C) Sanworks LLC, Rochester, New York, USA
+
+----------------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, version 3.
+
+This program is distributed  WITHOUT ANY WARRANTY and without even the 
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%}
+
+compatibleHTML = verLessThan('matlab', '25');
+
+if strcmp(moduleName, 'State Machine')
+    pingtime
+    if compatibleHTML
+        formattedPanelName = '<html>&nbsp;State<br>Machine</html>';
+    else
+        formattedPanelName = sprintf('State\nMachine');
+    end
+    return
+end
+
+uCase = (moduleName > 64 & moduleName < 91);
+lCase = (moduleName > 96 & moduleName < 123);
+if sum(uCase) == 2 && length(uCase) > 5 && sum(lCase) > 0
+    % if the module name is long enough split into two lines
+    capPos = find(uCase);
+    namePart1 = moduleName(1:capPos(2)-1);
+    namePart2 = moduleName(capPos(2):end);
+    if compatibleHTML
+        bufferLength = 5-length(namePart2);
+        if bufferLength < 1
+            bufferLength = 0;
+        end
+        buffer = ['<html>' repmat('&nbsp;', 1, bufferLength)];
+        namePart2 = [buffer namePart2(1:end-1) ' ' namePart2(end)];
+        formattedPanelName = ['<html>&nbsp;' namePart1 '<br>' namePart2];
+    else
+        namePart2 = [namePart2(1:end-1) ' ' namePart2(end)];
+        formattedPanelName = sprintf('%s\n%s', namePart1, namePart2);
+    end
+else
+    moduleName = [moduleName(1:end-1) ' ' moduleName(end)];
+    formattedPanelName = moduleName;
+end
+
+end

--- a/Functions/@BpodObject/BpodObject.m
+++ b/Functions/@BpodObject/BpodObject.m
@@ -647,13 +647,13 @@ classdef BpodObject < handle
             uistack(obj.GUIHandles.OverridePanel(panel), 'top');
             for i = offPanels
                 % Button -> gray
-                set(obj.GUIHandles.PanelButton(i), 'BackgroundColor', [0.37 0.37 0.37]);
+                set(obj.GUIHandles.PanelButton{i}, 'BackgroundColor', [0.37 0.37 0.37]);
                 set(obj.GUIHandles.OverridePanel(i), 'Visible', 'off');
             end
-            set(obj.GUIHandles.PanelButton(panel), 'BackgroundColor', [0.45 0.45 0.45]);
+            set(obj.GUIHandles.PanelButton{panel}, 'BackgroundColor', [0.45 0.45 0.45]);
             if isempty(strfind(obj.HostOS, 'Linux')) && ~verLessThan('matlab', '8.0.0') && verLessThan('matlab', '9.5.0')
                 for i = 1:obj.HW.n.UartSerialChannels+1
-                    jButton = findjobj(obj.GUIHandles.PanelButton(i));
+                    jButton = findjobj(obj.GUIHandles.PanelButton{i});
                     jButton.setBorderPainted(false);
                 end
             end

--- a/Functions/@BpodObject/InitializeGUI.m
+++ b/Functions/@BpodObject/InitializeGUI.m
@@ -1,3 +1,6 @@
+function obj = InitializeGUI(obj)
+% BpodObject.InitializeGUI() initializes the Bpod Console GUI.
+% InitializeGUI() is called on startup in Bpod.m
 
 %{
 ----------------------------------------------------------------------------
@@ -19,7 +22,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %}
 
-% BpodObject.InitializeGUI() initializes the Bpod Console GUI.
 % Setup figure label
 labelFontColor = [0.8 0.8 0.8];
 title = 'Bpod Console';
@@ -142,23 +144,7 @@ for i = 1:nTabs
     if i > 1
         if obj.Modules.Connected(i-1)
             thisModuleName = obj.Modules.Name{i-1};
-            uCase = (thisModuleName > 64 & thisModuleName < 91);
-            lCase = (thisModuleName > 96 & thisModuleName < 123);
-            if sum(uCase) == 2 && length(uCase) > 5 && sum(lCase) > 0
-                capPos = find(uCase);
-                namePart1 = thisModuleName(1:capPos(2)-1);
-                namePart2 = thisModuleName(capPos(2):end);
-                bufferLength = 5-length(namePart2);
-                if bufferLength < 1
-                    bufferLength = 0;
-                end
-                buffer = ['<html>' repmat('&nbsp;', 1, bufferLength)];
-                namePart2 = [buffer namePart2(1:end-1) ' ' namePart2(end)];
-                formattedModuleNames{i} = ['<html>&nbsp;' namePart1 '<br>' namePart2];
-            else
-                thisModuleName = [thisModuleName(1:end-1) ' ' thisModuleName(end)];
-                formattedModuleNames{i} = thisModuleName;
-            end
+            formattedModuleNames{i} = BpodLib.BpodObject.ui.formatPanelDisplayName(thisModuleName);
         else
             thisModuleName = 'None';
         end

--- a/Functions/@BpodObject/InitializeGUI.m
+++ b/Functions/@BpodObject/InitializeGUI.m
@@ -1,3 +1,4 @@
+
 %{
 ----------------------------------------------------------------------------
 
@@ -19,10 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %}
 
 % BpodObject.InitializeGUI() initializes the Bpod Console GUI.
-% InitializeGUI() is called on startup in Bpod.m
-
-function obj = InitializeGUI(obj)
-
 % Setup figure label
 labelFontColor = [0.8 0.8 0.8];
 title = 'Bpod Console';
@@ -131,7 +128,7 @@ pluginPanelWidth = 575;
 pluginPanelOffset = 145;
 nTabs = obj.HW.n.UartSerialChannels+1;
 tabWidth = (pluginPanelWidth)/nTabs;
-moduleNames = {'<html>&nbsp;State<br>Machine', 'Serial 1', 'Serial 2', 'Serial 3', 'Serial 4', 'Serial 5'};
+moduleNames = {BpodLib.BpodObject.ui.formatPanelDisplayName('State Machine'), 'Serial 1', 'Serial 2', 'Serial 3', 'Serial 4', 'Serial 5'};
 obj.GUIHandles.PanelButton = cell(1, nTabs);
 formattedModuleNames = moduleNames;
 tabPos = pluginPanelOffset;

--- a/Functions/@BpodObject/InitializeGUI.m
+++ b/Functions/@BpodObject/InitializeGUI.m
@@ -131,8 +131,8 @@ pluginPanelWidth = 575;
 pluginPanelOffset = 145;
 nTabs = obj.HW.n.UartSerialChannels+1;
 tabWidth = (pluginPanelWidth)/nTabs;
-obj.GUIHandles.PanelButton = zeros(1,nTabs);
 moduleNames = {'<html>&nbsp;State<br>Machine', 'Serial 1', 'Serial 2', 'Serial 3', 'Serial 4', 'Serial 5'};
+obj.GUIHandles.PanelButton = cell(1, nTabs);
 formattedModuleNames = moduleNames;
 tabPos = pluginPanelOffset;
 obj.GUIData.DefaultPanel = ones(1,nTabs);
@@ -167,7 +167,7 @@ for i = 1:nTabs
         end
     end
     % Draw tab
-    obj.GUIHandles.PanelButton(i) = uicontrol('Style', 'pushbutton',...
+    obj.GUIHandles.PanelButton{i} = uicontrol('Style', 'pushbutton',...
         'String', formattedModuleNames{i},...
         'Callback', @(h,e)obj.SwitchPanels(i),...
         'BackgroundColor', [0.37 0.37 0.37],...
@@ -177,7 +177,7 @@ for i = 1:nTabs
         'FontName', buttonFont);
     tabPos = tabPos + tabWidth;
     if isempty(strfind(obj.HostOS, 'Linux')) && ~verLessThan('matlab', '8.0.0') && verLessThan('matlab', '9.5.0')
-        jButton = findjobj(obj.GUIHandles.PanelButton(i));
+        jButton = findjobj(obj.GUIHandles.PanelButton{i});
         jButton.setBorderPainted(false);
     end
     % Draw panel
@@ -227,7 +227,7 @@ for i = 1:nTabs
     drawnow;
     set(obj.GUIHandles.OverridePanel(i), 'Visible', 'off');
 end
-set (obj.GUIHandles.PanelButton(1), 'BackgroundColor', [0.45 0.45 0.45]); % Set first button active
+set(obj.GUIHandles.PanelButton{1}, 'BackgroundColor', [0.45 0.45 0.45]); % Set first button active
 set(obj.GUIHandles.OverridePanel(1), 'Visible', 'on');
 obj.GUIData.CurrentPanel = 1;
 axes(obj.GUIHandles.Console);
@@ -241,7 +241,7 @@ if isempty(strfind(obj.HostOS, 'Linux'))
     end
     if isempty(strfind(obj.HostOS, 'Linux')) && ~verLessThan('matlab', '8.0.0') && verLessThan('matlab', '9.5.0')
         for i = 1:obj.HW.n.UartSerialChannels+1
-            jButton = findjobj(obj.GUIHandles.PanelButton(i));
+            jButton = findjobj(obj.GUIHandles.PanelButton{i});
             jButton.setBorderPainted(false);
         end
     end

--- a/Functions/@BpodObject/refreshGUIPanels.m
+++ b/Functions/@BpodObject/refreshGUIPanels.m
@@ -1,3 +1,7 @@
+function obj = refreshGUIPanels(obj)
+% BpodObject.refreshGUIPanels() is called by BpodObject.LoadModules() to
+% update the console GUI tabs with the names of the connected modules
+
 %{
 ----------------------------------------------------------------------------
 
@@ -18,14 +22,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %}
 
-% BpodObject.refreshGUIPanels() is called by BpodObject.LoadModules() to
-% update the console GUI tabs with the names of the connected modules
-
-function obj = refreshGUIPanels(obj)
 if obj.Status.BeingUsed == 0
 
     % Set default tab names
-    moduleNames = {'<html>&nbsp;State<br>Machine', 'Serial 1', 'Serial 2', 'Serial 3', 'Serial 4', 'Serial 5'};
+    moduleNames = {BpodLib.BpodObject.ui.formatPanelDisplayName('State Machine'), 'Serial 1', 'Serial 2', 'Serial 3', 'Serial 4', 'Serial 5'};
 
     % Format module names for display on tab buttons
     formattedModuleNames = moduleNames;
@@ -34,22 +34,7 @@ if obj.Status.BeingUsed == 0
     for i = 2:nTabs
         if obj.Modules.Connected(i-1)
             thisModuleName = obj.Modules.Name{i-1};
-            uCase = (thisModuleName > 64 & thisModuleName < 91);
-            if sum(uCase) == 2 && length(uCase) > 5
-                capPos = find(uCase);
-                namePart1 = thisModuleName(1:capPos(2)-1);
-                namePart2 = thisModuleName(capPos(2):end);
-                bufferLength = 5-length(namePart2);
-                if bufferLength < 1
-                    bufferLength = 0;
-                end
-                buffer = ['<html>' repmat('&nbsp;', 1, bufferLength)];
-                namePart2 = [buffer namePart2(1:end-1) ' ' namePart2(end)];
-                formattedModuleNames{i} = ['<html>&nbsp;' namePart1 '<br>' namePart2];
-            else
-                thisModuleName = [thisModuleName(1:end-1) ' ' thisModuleName(end)];
-                formattedModuleNames{i} = thisModuleName;
-            end
+            formattedModuleNames{i} = BpodLib.BpodObject.ui.formatPanelDisplayName(thisModuleName);
         else
             thisModuleName = 'None';
         end

--- a/Functions/@BpodObject/refreshGUIPanels.m
+++ b/Functions/@BpodObject/refreshGUIPanels.m
@@ -55,7 +55,7 @@ if obj.Status.BeingUsed == 0
         end
 
         % Update tab
-        set(obj.GUIHandles.PanelButton(i), 'String', formattedModuleNames{i});
+        set(obj.GUIHandles.PanelButton{i}, 'String', formattedModuleNames{i});
 
         % Clear panel contents
         set(obj.GUIHandles.OverridePanel(i), 'Visible', 'on');
@@ -101,11 +101,11 @@ if obj.Status.BeingUsed == 0
     end
 
     for i = 2:nTabs
-        set(obj.GUIHandles.PanelButton(i), 'BackgroundColor', [0.37 0.37 0.37]);
+        set(obj.GUIHandles.PanelButton{i}, 'BackgroundColor', [0.37 0.37 0.37]);
     end
 
     % Final formatting tasks
-    set (obj.GUIHandles.PanelButton(1), 'BackgroundColor', [0.45 0.45 0.45]); % Set first button active
+    set(obj.GUIHandles.PanelButton{1}, 'BackgroundColor', [0.45 0.45 0.45]); % Set first button active
     set(obj.GUIHandles.OverridePanel(1), 'Visible', 'on');
     uistack(obj.GUIHandles.OverridePanel(1),'top');
     axes(obj.GUIHandles.Console);
@@ -114,7 +114,7 @@ if obj.Status.BeingUsed == 0
     % Clear button borders
     if isempty(strfind(obj.HostOS, 'Linux')) && ~verLessThan('matlab', '8.0.0') && verLessThan('matlab', '9.5.0')
         for i = 1:nTabs
-            jButton = findjobj(obj.GUIHandles.PanelButton(i));
+            jButton = findjobj(obj.GUIHandles.PanelButton{i});
             jButton.setBorderPainted(false);
         end
     end


### PR DESCRIPTION
`BpodSystem.GUIHandles.PanelButton{1}` points to a `uicontrol('Style', 'pushbutton', _)` that uses two lines for "State Machine" and for modules with longer names, like "RotaryEncoder1". The use of html in `uicontrol.String` is unsupported as of 2025a and was rendering the characters as raw (i.e. `'<html>&nbsp;State<br>Machine</html>'`)

This PR fixes this by doing a version check for <25 to use the existing html method, and otherwise using `sprintf('%s\n%s', _)` (which would only render everything before `\n` in 2021b). I don't know exactly when the support ended, if users report an issue we can change the version check.