### PR TITLE
Make ISO8601 the default output of `isotime`

### DIFF
--- a/Examples/Example Calibration Files/LiquidCalibration.json
+++ b/Examples/Example Calibration Files/LiquidCalibration.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "modification_datetime": "2000-01-01 00:00:00"
+    "modification_datetime": "2000-01-01T00:00:00"
   },
   "ValveDatas": [
     {
       "ValveName": "Valve1",
-      "LastDateModified": "2000-01-01 00:00:00",
+      "LastDateModified": "2000-01-01T00:00:00",
       "Coeffs": [
         -0.305761022808475,
         9.3201104694953631,
@@ -35,7 +35,7 @@
     },
     {
       "ValveName": "Valve3",
-      "LastDateModified": "2000-01-01 00:00:00",
+      "LastDateModified": "2000-01-01T00:00:00",
       "Coeffs": [
         0.047977795400474969,
         5.7240285487708258,

--- a/Functions/+BpodLib/+calibration/+liquid/+compatibility/createDummyData.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+compatibility/createDummyData.m
@@ -54,7 +54,7 @@ valve3.addMeasurement(66, 8.5);
 
 % todo: these dates are different to the .JSON in Examples/
 % Update LastDateModified to reflect the dummy data
-valve1.LastDateModified = '2016-11-17 16:08:26';  % original from Bpod_Gen2
+valve1.LastDateModified = '2016-11-17T16:08:26';  % original from Bpod_Gen2
 % valve3.LastDateModified = char(datetime('2024-07-17 09:22:28'));  % the date of this function's creation
 valve3.LastDateModified = "";
 

--- a/Functions/+BpodLib/+calibration/+liquid/+io/checkDefaultData.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+io/checkDefaultData.m
@@ -21,7 +21,7 @@ if isa(LiquidCal, 'struct')
         isDefault = 'false';
     end
 elseif isa(LiquidCal, 'BpodLib.calibration.liquid.ValveDataManagerClass')
-    if isfield(LiquidCal.metadata, 'modification_datetime') && ~strcmp(LiquidCal.metadata.modification_datetime, "2000-01-01 00:00:00")
+    if isfield(LiquidCal.metadata, 'modification_datetime') && ~strcmp(LiquidCal.metadata.modification_datetime, "2000-01-01T00:00:00")
         isDefault = 'false';
     end
 elseif isempty(LiquidCal)

--- a/Functions/+BpodLib/+calibration/+liquid/+ui/TestSpecificAmountGUI.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+ui/TestSpecificAmountGUI.m
@@ -208,7 +208,7 @@ methods
         end
 
         % Print results into command window
-        fprintf('Bpod liquid calibration (%s) %s\n', BpodLib.utils.getCurrentCOM(obj.BpodSystem), BpodLib.utils.isotime())
+        fprintf('Bpod liquid calibration (%s) %s\n', BpodLib.utils.getCurrentCOM(obj.BpodSystem), BpodLib.utils.isotime('display'))
         fprintf('    Expected amount to dispense per pulse: %.3f uL\n', str2double(obj.GUIHandles.SpecificAmtEdit.String));
         fprintf('    Acceptable tolerance: %.2f%%\n', str2double(obj.GUIHandles.ToleranceDropmenu.String{obj.GUIHandles.ToleranceDropmenu.Value}));
         fprintf('    %d pulses delivered over %.2f seconds\n', str2double(obj.GUIHandles.nPulsesDropmenu.String{obj.GUIHandles.nPulsesDropmenu.Value}), obj.testDuration);

--- a/Functions/+BpodLib/+utils/isotime.m
+++ b/Functions/+BpodLib/+utils/isotime.m
@@ -4,8 +4,8 @@ function datestring = isotime(varargin)
 %
 % Arguments
 % ---------
-% format : char
-%     Format of the output string, either 'datetime' (default), 'iso8601', 'date', or 'time'
+% format : char, optional (default = 'iso')
+%     Format of the output string, either 'iso', 'display', 'path', 'date', or 'time'
 %
 % Returns
 % -------
@@ -32,23 +32,24 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %}
 
-datestring = datetime('now', 'Format', 'yyyy-MM-dd HH:mm:ss');
+% define time as quickly as possible
+datestring = datetime('now', 'Format', 'yyyy-MM-dd''T''HH:mm:ss');
 
 if isempty(varargin)
     return
 end
 
 p = inputParser();
-p.addOptional('format', 'datetime', @ischar);
+p.addOptional('format', 'iso', @ischar);
 p.parse(varargin{:});
 
 switch lower(p.Results.format)
-    case 'datetime'
+    case 'display'
         datestring = datetime(datestring, 'Format', 'yyyy-MM-dd HH:mm:ss');
-    case 'iso8601'
-        datestring = datetime(datestring, 'Format', 'yyyy-MM-ddTHH:mm:ss');
+    case 'iso'
+        datestring = datetime(datestring, 'Format', 'yyyy-MM-dd''T''HH:mm:ss');
     case 'path'
-        % This is used for filepathing, hardcoded into SaveBpodData
+        % The equivalent is used in `BpodSystem.Path.CurrentDataFile =`
         datestring = datetime(datestring, 'Format', 'yyyyMMdd_HHmmss');
     case 'date'
         datestring = datetime(datestring, 'Format', 'yyyy-MM-dd');

--- a/Tests/BpodLib/calibration/liquid/testData/ExpectedLiquidCalibration.json
+++ b/Tests/BpodLib/calibration/liquid/testData/ExpectedLiquidCalibration.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "modification_datetime": "2016-11-17 16:08:26"
+    "modification_datetime": "2016-11-17T16:08:26"
   },
   "ValveDatas": [
     {
       "ValveName": "Valve1",
-      "LastDateModified": "2016-11-17 16:08:26",
+      "LastDateModified": "2016-11-17T16:08:26",
       "Coeffs": [
         -0.305761022808475,
         9.3201104694953631,

--- a/Tests/BpodLib/calibration/liquid/test_liquidcalibration.m
+++ b/Tests/BpodLib/calibration/liquid/test_liquidcalibration.m
@@ -86,7 +86,7 @@ function test_JSONRead(testCase)
 
     % Verify datetime of first
     Valve1 = ValveManager.getValve('Valve1');
-    originalDateTime = datetime(testCase.TestData.OriginalLiquidCal(1).LastDateModified, 'ConvertFrom', 'datenum', 'Format', 'yyyy-MM-dd HH:mm:ss');
+    originalDateTime = datetime(testCase.TestData.OriginalLiquidCal(1).LastDateModified, 'ConvertFrom', 'datenum', 'Format', 'yyyy-MM-dd''T''HH:mm:ss');
     testCase.verifyEqual(Valve1.LastDateModified, char(originalDateTime));
 end
 


### PR DESCRIPTION
`BpodLib.utils.isotime()` currently creates a `datetime` object that has a space between the date and time. That's not ISO, so the behaviour has been changed to have a `'T'` instead of `' '` . The reason I got to this is bpod-rig's calibration data representation will use this format so it'll be neater to line up.