### PR TITLE
Fix crash on emulator load

### DIFF
--- a/Bpod.m
+++ b/Bpod.m
@@ -109,8 +109,6 @@ else
         end
     end
 end
-BpodLib.calibration.liquid.io.report(BpodSystem.CalibrationTables.LiquidCal)
-BpodLib.path.verifyPathing(BpodSystem);
 
 function emulator_setup(varargin)
 % Runs setup with emulator mode flag set to 'true'.
@@ -128,6 +126,9 @@ BpodSystem.SetupHardware();
 BpodSystem.InitializeGUI();
 BpodSystem.Status.Initialized = true;
 evalin('base', 'global BpodSystem')
+
+BpodLib.calibration.liquid.io.report(BpodSystem.CalibrationTables.LiquidCal)
+BpodLib.path.verifyPathing(BpodSystem);
 
 function emulator_dialog
 % Launches a GUI indicating that hardware connection has failed.

--- a/Functions/+BpodLib/+utils/getCurrentCOM.m
+++ b/Functions/+BpodLib/+utils/getCurrentCOM.m
@@ -34,7 +34,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %}
 
-if isempty(BpodSystem.SerialPort)
+if ~isfield(BpodSystem, 'SerialPort')
     comport = 'EMU';
 else
     comport = BpodSystem.SerialPort.PortName;


### PR DESCRIPTION
Hi @JSNeuroDev and @ogeesan 

I ran into an issue where launching the emulator caused the startup to crash. It seems the root of this came from two places:
1) In Bpod.m if there is no Bpod , `BpodSystem` is cleared so the two BpodLib calls fail. I moved the two calls inside of  `bpod_setup` where we can guarantee `BpodSystem` already exists
2) If in emulator mode BpodSystem.SerialPort does not exist. `isempty` will error out if a field doesn't exist, `~isfield` accomplishes the same check without an error. 