### PR TITLE
Fix getCurrentCOM

### DIFF
--- a/Functions/+BpodLib/+calibration/+liquid/+portarray/createValveManager.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+portarray/createValveManager.m
@@ -32,8 +32,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %}
 
 PortArrayCal = BpodLib.calibration.liquid.ValveDataManagerClass();
-
-for moduleNumber = 1:BpodSystem.Modules.nModules
+nModules = numel(BpodSystem.Modules.Connected);
+for moduleNumber = 1:nModules
     for valveIndex = 1:8 % Todo: Only the connected PA's?
         PortArrayCal.createValve(sprintf('PA%i_%i', moduleNumber, valveIndex));
     end

--- a/Functions/+BpodLib/+utils/getCurrentCOM.m
+++ b/Functions/+BpodLib/+utils/getCurrentCOM.m
@@ -34,7 +34,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %}
 
-if ~isfield(BpodSystem, 'SerialPort')
+if ~isprop(BpodSystem, 'SerialPort') || isempty(BpodSystem.SerialPort)
     comport = 'EMU';
 else
     comport = BpodSystem.SerialPort.PortName;

--- a/Tests/BpodLib/calibration/liquid/test_save.m
+++ b/Tests/BpodLib/calibration/liquid/test_save.m
@@ -15,27 +15,28 @@ function setup(testCase)
     valveManager.loadData(fullfile(testDataFolder, 'ExpectedLiquidCalibration.json'))
     testCase.TestData.mockValveDataManager = valveManager;
 
-    % Create various filesetups
-    mockBpod = struct();
-    mockBpod.SerialPort.PortName = 'COM13';
-    mockBpod.CalibrationTables.LiquidCal = valveManager;
+    % Create various file setups
     % Regular setup
+    mockBpod_regular = BpodLib.BpodObject.MockBpodObject('COM13');
+    mockBpod_regular.CalibrationTables.LiquidCal = valveManager;
     folderPath = fullfile(rootPath, 'CF Regular');
-    mockBpod.Path.LocalDir = folderPath;
+    mockBpod_regular.Path.LocalDir = folderPath;
     mkdir(folderPath)
     folderPath = fullfile(folderPath, 'Config');
     mkdir(folderPath);
-    testCase.TestData.regularBpod = mockBpod;
+    testCase.TestData.regularBpod = mockBpod_regular;
 
     % Regular multi
+    mockBpod_multi = BpodLib.BpodObject.MockBpodObject('COM13');
+    mockBpod_multi.CalibrationTables.LiquidCal = valveManager;
     folderPath = fullfile(rootPath, 'CF Multi');
     mkdir(folderPath)
-    mockBpod.Path.LocalDir = folderPath;
+    mockBpod_multi.Path.LocalDir = folderPath;
     folderPath = fullfile(folderPath, 'Config');
     mkdir(folderPath);
     mkdir(fullfile(folderPath, 'Machine-COM13'))
     mkdir(fullfile(folderPath, 'Machine-COM5'))
-    testCase.TestData.multiBpod = mockBpod;
+    testCase.TestData.multiBpod = mockBpod_multi;
 end
 
 function teardown(testCase)

--- a/Tests/BpodLib/utils/test_utils.m
+++ b/Tests/BpodLib/utils/test_utils.m
@@ -7,8 +7,7 @@ function setup(testCase)
     testCase.TestData.rootPath = rootPath;
     mkdir(testCase.TestData.rootPath)
     
-    mockBpod = struct();
-    mockBpod.SerialPort.PortName = 'COM13';
+    mockBpod = BpodLib.BpodObject.MockBpodObject('COM13');
     mockBpod.Path.LocalDir = testCase.TestData.rootPath;
     testCase.TestData.mockBpod = mockBpod;
 end


### PR DESCRIPTION
#40 introduced changes that broke some tests, namely through a change to `BpodLib.utils.getCurrentCOM`. The change would cause it to fail to identify the COM, thereby reverting back to 'EMU'. The outcome would be that multi-setups may have configurations that are strangely tied to the 'EMU' setup.

The bug has been fixed, and the test code has been updated to reflect the more robust approach.

Separately, the port array module's calibration file creation has been modified to handle different stages of setup (`.nModules`) is guaranteed to exist in test contexts.