### PR TITLE
Remove the SerialPort field when the serial port fails to connect

### DIFF
--- a/Functions/@BpodObject/Connect2BpodSM.m
+++ b/Functions/@BpodObject/Connect2BpodSM.m
@@ -107,6 +107,9 @@ end
 if found
     obj.EmulatorMode = 0;
 else
+    obj.SerialPort = [];
+    % If no serial port is found, drop the field
+
     if sum(portsTried) > 0
         autoModeMessage = [];
         if autoMode


### PR DESCRIPTION
Due to how `Connect2BpodSM.m` sets `BpodSystem.SerialPort`, if there is no connection it is set to a deleted handle. This causes an error when attempting to launch the emulator, as the check in `getCurrentCom.m` will fail since `SerialPort` is a field of the BpodSystem, but it is just a deleted handle.

This patch makes sure the SerialPort field is dropped from the BpodSystem if no connection is made so the emulator logic properly runs.

Cheers!
