### PR TITLE
Improve handling for example calibration data on fresh setup

### DIFF
--- a/Examples/Example Calibration Files/LiquidCalibration.json
+++ b/Examples/Example Calibration Files/LiquidCalibration.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
-    "modification_datetime": "2000-01-01T00:00:00"
+    "modification_datetime": "2000-01-01T00:00:00",
+    "COM": "example data"
   },
   "ValveDatas": [
     {

--- a/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
+++ b/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
@@ -103,7 +103,8 @@ end
 %% -- Calibration Files
 calFolder = BpodLib.path.getPath('calibration', BpodSystem, 'LocalDir', LocalDir);
 
-if ~isfile(fullfile(Path.SettingsDir, 'LiquidCalibration.json')) && ~BpodLib.path.compatibility.isLegacySettings(Path.LocalDir)
+freshSetup = ~isfile(fullfile(Path.SettingsDir, 'LiquidCalibration.json')) && ~BpodLib.path.compatibility.isLegacySettings(Path.LocalDir);
+if freshSetup
     fileNames = {'LiquidCalibration.json', 'SoundCalibration.mat', 'Readme.txt'};
     for idx = 1:numel(fileNames)
         fileName = fileNames{idx};
@@ -119,6 +120,7 @@ try
     BpodSystem.CalibrationTables.LiquidCal = BpodLib.calibration.liquid.io.load('BpodSystem', BpodSystem, 'LocalDir', LocalDir, 'type', 'statemachine');
     if strcmp(BpodLib.calibration.liquid.utils.checkCOM(BpodSystem), 'no')
         if p.Results.verbose
+            % if fresh setup skip because UI already said to check out the thing.
             BpodLib.calibration.liquid.ui.VerifyCOMGUI(BpodSystem);
         end
     end

--- a/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
+++ b/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
@@ -120,7 +120,6 @@ try
     BpodSystem.CalibrationTables.LiquidCal = BpodLib.calibration.liquid.io.load('BpodSystem', BpodSystem, 'LocalDir', LocalDir, 'type', 'statemachine');
     if strcmp(BpodLib.calibration.liquid.utils.checkCOM(BpodSystem), 'no')
         if p.Results.verbose
-            % if fresh setup skip because UI already said to check out the thing.
             BpodLib.calibration.liquid.ui.VerifyCOMGUI(BpodSystem);
         end
     end

--- a/Functions/+BpodLib/+calibration/+liquid/+compatibility/createDummyData.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+compatibility/createDummyData.m
@@ -52,10 +52,8 @@ valve3.addMeasurement(59, 7.5);
 valve3.addMeasurement(35, 3.5);
 valve3.addMeasurement(66, 8.5);
 
-% todo: these dates are different to the .JSON in Examples/
-% Update LastDateModified to reflect the dummy data
-valve1.LastDateModified = '2016-11-17T16:08:26';  % original from Bpod_Gen2
-% valve3.LastDateModified = char(datetime('2024-07-17 09:22:28'));  % the date of this function's creation
-valve3.LastDateModified = "";
-
+% Original MATLAB struct file had LastDateModified equivalent to 2016-11-17T16:08:26
+dateString = "2000-01-01T00:00:00";
+valve1.LastDateModified = dateString;
+valve3.LastDateModified = dateString;
 end

--- a/Functions/+BpodLib/+calibration/+liquid/+utils/checkCOM.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+utils/checkCOM.m
@@ -40,6 +40,12 @@ if ~isfield(LiquidCal.metadata, 'COM')
     return
 end
 
+if strcmp(LiquidCal.metadata.COM, "example data")
+    % If the file's COM is example data, the liquid cal is just placeholder
+    % so we count that as "unknown"
+    return
+end
+
 if strcmp(LiquidCal.metadata.COM, BpodSystemCOM)
     matchingCOM = 'yes';
 else

--- a/Functions/+BpodLib/+calibration/+liquid/+utils/createDefaultFile.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+utils/createDefaultFile.m
@@ -1,0 +1,24 @@
+function createDefaultFile()
+% Create the default LiquidCalibration.json file in Examples/
+
+LiquidCal= BpodLib.calibration.liquid.compatibility.createDummyData();
+rootPath = BpodLib.path.getPath('root');
+filePath = fullfile(rootPath, 'Examples/Example Calibration Files/LiquidCalibration.json');
+
+% Insert data
+dateString = "2000-01-01T00:00:00";
+saveData = LiquidCal.createSaveData();
+saveData.metadata.modification_datetime = dateString;
+saveData.metadata.COM = "example data";
+
+if verLessThan('matlab', '9.10') % R2021a is 9.10
+    writeData = jsonencode(saveData);
+else
+    writeData = jsonencode(saveData, 'PrettyPrint', true);
+end
+fid = fopen(filePath, 'w');
+fwrite(fid, writeData, 'char');
+fclose(fid);
+
+
+end

--- a/Tests/BpodLib/calibration/liquid/test_dataWarning.m
+++ b/Tests/BpodLib/calibration/liquid/test_dataWarning.m
@@ -56,3 +56,14 @@ function test_loadFailure(testCase)
     BpodLib.calibration.liquid.io.checkDefaultData([]);
     BpodLib.calibration.liquid.io.report([])
 end
+
+function test_load_fresh(testCase)
+    BpodSystem = BpodTest.MockBpodObject('EMU');
+    filepath = fullfile(BpodLib.path.getPath('root'), 'Examples/Example Calibration Files/LiquidCalibration.json');
+    LiquidCal = BpodLib.calibration.liquid.ValveDataManagerClass('filepath', filepath);
+    
+    BpodSystem.CalibrationTables.LiquidCal = LiquidCal;
+    LiquidCal.metadata.COM
+    BpodLib.calibration.liquid.utils.checkCOM(BpodSystem)
+    testCase.verifyTrue(strcmp('unknown', BpodLib.calibration.liquid.utils.checkCOM(BpodSystem)));
+end

--- a/Tests/BpodLib/calibration/liquid/test_liquidcalibration.m
+++ b/Tests/BpodLib/calibration/liquid/test_liquidcalibration.m
@@ -22,7 +22,6 @@ function setupOnce(testCase)
     OriginalLiquidCal(3).Coeffs = [0.0479777954004750,5.72402854877083,13.6002180808882];
 
     testCase.TestData.OriginalLiquidCal = OriginalLiquidCal;
-%     testCase.TestData.expectedJSONPath = fullfile('testData/ExpectedLiquidCalibration.json');
     [testFolder, ~, ~] = fileparts(mfilename('fullpath'));
     testDataFolder = fullfile(testFolder, 'testData');
     testCase.TestData.expectedJSONPath = fullfile(testDataFolder, 'ExpectedLiquidCalibration.json');

--- a/Tests/BpodLib/calibration/liquid/test_liquidcalibration.m
+++ b/Tests/BpodLib/calibration/liquid/test_liquidcalibration.m
@@ -34,33 +34,6 @@ function teardownOnce(testCase)
     rmdir(testCase.TestData.rootPath, 's');
 end
 
-
-function test_JSONWrite(testCase)
-    % Test that the JSON format being saved by ValveManagerClass is correct
-    
-    % Create test data and write JSON
-    dummyValveManager = BpodLib.calibration.liquid.compatibility.createDummyData();
-    dummyjsonPath = fullfile(testCase.TestData.rootPath, 'test.json');
-    dummyValveManager.saveData(dummyjsonPath);
-    
-    % Read both files
-    jsonData = fileread(dummyjsonPath);
-    expectedData = fileread(testCase.TestData.expectedJSONPath);
-    
-    % Normalize both JSON strings
-    jsonData = normalizeJSON(jsonData);
-    expectedData = normalizeJSON(expectedData);
-    
-    % Compare the normalized versions
-    testCase.verifyEqual(jsonData, expectedData, 'JSON content does not match expected');
-    
-    % If still failing, provide diagnostic output
-    if ~isequal(jsonData, expectedData)
-        fprintf('\n=== JSON COMPARISON FAILURE DETAILS ===\n');
-        showDiff(jsonData, expectedData);
-    end
-end
-
 function test_JSONRead(testCase)
     % Test ValveDataManager's reading, ensuring values are in the right
     % places


### PR DESCRIPTION
In #42 the UIs were not properly triggered because the COM port field is absent. This PR:

- Creates a function that populates the example data, increasing testability of the data.
- Uses a special case `"example data"` COM for the example data which is recognised as being non-user data during COM match check.

This ensures that UI warnings about COM mismatch are not triggered if the user is yet to even touch the liquid calibration data.

Note that the warnings concerning "old calibration" were turned off in bc33156 until a UI to opt in is built.