### PR TITLE
Improve LiquidCalibration.json COM mismatch UI

### DIFF
--- a/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
+++ b/Functions/+BpodLib/+BpodObject/+setup/updatePathAndSettings.m
@@ -117,11 +117,6 @@ end
 
 try
     BpodSystem.CalibrationTables.LiquidCal = BpodLib.calibration.liquid.io.load('BpodSystem', BpodSystem, 'LocalDir', LocalDir, 'type', 'statemachine');
-    if strcmp(BpodLib.calibration.liquid.utils.checkCOM(BpodSystem), 'no')
-        if p.Results.verbose
-            BpodLib.calibration.liquid.ui.VerifyCOMGUI(BpodSystem);
-        end
-    end
 catch err
     if strcmp(err.identifier, 'BpodLib:LiquidCalibrationLoad:FileNotFound')
         BpodSystem.CalibrationTables.LiquidCal = [];
@@ -226,5 +221,14 @@ if ~strcmp(BpodSystem.Path.SettingsDir, BpodLib.path.getPath('Settings', BpodSys
     warning('BpodLib:PathSetup:SettingsMatchFail','SettingsDir setup does not match BpodLib path. This will cause issues with loading settings.');
     % I don't see why this would happen, but if it does it's going to be a problem.
 end
+
+%% -- Final verifications
+% Functions that require BpodSystem to be fully setup can be called here.
+if strcmp(BpodLib.calibration.liquid.utils.checkCOM(BpodSystem), 'no')
+    if p.Results.verbose
+        BpodLib.calibration.liquid.ui.VerifyCOMGUI(BpodSystem);
+    end
+end
+
 
 end

--- a/Functions/+BpodLib/+calibration/+liquid/+ui/VerifyCOMGUI.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+ui/VerifyCOMGUI.m
@@ -34,13 +34,23 @@ if BpodLib.multi.isMultiSetup(BpodSystem)
 
     % Multi setup - ask user which machine to import from.
     prompt = {
-        sprintf('The Bpod COM port (%s) does not match the', BpodLib.utils.getCurrentCOM(BpodSystem));
+        sprintf('The Bpod COM port (%s) does not match', BpodLib.utils.getCurrentCOM(BpodSystem));
         sprintf('liquid calibration file''s COM port (%s).', LiquidCal.metadata.COM);
         'Please select which COM to copy in the liquid';
         'calibration file from:'
     };
     ignoreOption = 'I will remember to recalibrate. (ignore)';
-    options = [{ignoreOption}, availableMachines'];
+    machineNames = [{ignoreOption}, availableMachines'];
+    options = machineNames;
+
+    % Replace thisMachineName with '(current machine)' in the list
+    [~, thisMachineName] = fileparts(BpodLib.path.getPath('config', BpodSystem))
+    for i = 1:length(options)
+        if strcmp(options{i}, thisMachineName)
+            options{i} = sprintf('%s (use existing file)', thisMachineName);
+            break
+        end
+    end
 
     [selectionIdx, ok] = listdlg('PromptString', prompt, ...
         'SelectionMode', 'single', ...
@@ -51,7 +61,7 @@ if BpodLib.multi.isMultiSetup(BpodSystem)
         return
     end
 
-    selectedMachine = options{selectionIdx};
+    selectedMachine = machineNames{selectionIdx};
     if strcmp(selectedMachine, ignoreOption)
         return
     end

--- a/Functions/+BpodLib/+calibration/+liquid/+ui/VerifyCOMGUI.m
+++ b/Functions/+BpodLib/+calibration/+liquid/+ui/VerifyCOMGUI.m
@@ -27,7 +27,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 %}
 
-assert(strcmp(BpodLib.calibration.liquid.utils.checkCOM(BpodSystem), 'no'))
 LiquidCal = BpodSystem.CalibrationTables.LiquidCal;  % the handle is extracted for convenience
 
 if BpodLib.multi.isMultiSetup(BpodSystem)


### PR DESCRIPTION
In #42 it was noted that:
> In a run with the multi-setup, the GUI listed the COM port it claims it couldn't detect

This PR should make it clearer what is happening by referring to the current machine's settings file as "(use existing file)".

### An explanation
A LiquidCalibration.json has two COM properties: the one inside of its metadata and also the Config folder that the file lives within. During startup, `BpodLib.BpodObject.setup.updatePathAndSettings.m` will:
1. Load the LiquidCalibration.json that lives in the appropriate Config folder
2. Check the file's COM to see if it matches the current machine's COM port.
3. If mismatch, display all Config sources and ask a user to pick one (or ignore).

For this reason, the current COM port will always be in the list of available Config sources. This UI handles the situation where a user replaces one state machine with another and the user copies across those config files. This allows the COM metadata to be overwritten without requiring a recalibration. It's sort of a niche use-case -- at some point we could build an interface to allow users to move configuration files around.

To produce the GUI you can use this snippet:
```matlab
BpodSystem = BpodTest.MockBpodObject('yourCOM');  % this require Tests/ to be on the Path
BpodSystem.Path.LocalDir = fullfile(fileparts(BpodLib.path.getPath('root')), 'Bpod Local');
BpodSystem.CalibrationTables.LiquidCal = BpodLib.calibration.liquid.io.load('BpodSystem', BpodSystem, 'type', 'statemachine');
BpodLib.calibration.liquid.ui.VerifyCOMGUI(BpodSystem)
```

<img width="347" height="509" alt="image" src="https://github.com/user-attachments/assets/f92807ff-91b1-4ef4-a312-310e5f571d20" />
